### PR TITLE
feat: add Next.js parser and fix ASP.NET analyzer issues

### DIFF
--- a/analyzer/AutoDocAnalyzer.csproj
+++ b/analyzer/AutoDocAnalyzer.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/analyzer/Models/RouteInfo.cs
+++ b/analyzer/Models/RouteInfo.cs
@@ -67,6 +67,9 @@ public class RequestBodyInfo
     [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
+    [JsonPropertyName("contentType")]
+    public string? ContentType { get; set; }
+
     [JsonPropertyName("properties")]
     public List<PropertyInfo> Properties { get; set; } = new();
 }

--- a/analyzer/Parsers/ControllerParser.cs
+++ b/analyzer/Parsers/ControllerParser.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -185,9 +186,17 @@ public class ControllerParser
 
         var path = "/" + string.Join("/", parts);
 
-        // Convert ASP.NET route params {id} to OpenAPI style
+        // Strip route constraints: {id:guid} → {id}, {slug:regex(...)} → {slug}
+        path = Regex.Replace(path, @"\{(\w+):[^}]+\}", "{$1}");
+
         return path;
     }
+
+    private static readonly HashSet<string> FormFileTypes = new()
+    {
+        "IFormFile", "IFormFileCollection", "IFormFile?",
+        "List<IFormFile>", "IList<IFormFile>", "IEnumerable<IFormFile>",
+    };
 
     private void ExtractParameters(MethodDeclarationSyntax method, RouteInfo route)
     {
@@ -196,6 +205,21 @@ public class ControllerParser
             var paramName = param.Identifier.Text;
             var paramType = param.Type?.ToString() ?? "string";
             var source = DetermineParamSource(param, route.Path);
+
+            // IFormFile → multipart/form-data
+            if (FormFileTypes.Contains(paramType))
+            {
+                route.RequestBody = new RequestBodyInfo
+                {
+                    Type = paramType,
+                    ContentType = "multipart/form-data",
+                    Properties = new List<Models.PropertyInfo>
+                    {
+                        new() { Name = paramName, Type = "binary", Required = true },
+                    },
+                };
+                continue;
+            }
 
             if (source == "body")
             {
@@ -257,6 +281,20 @@ public class ControllerParser
         };
     }
 
+    private static readonly Dictionary<string, int> ResultMethodStatusCodes = new()
+    {
+        { "Ok", 200 },
+        { "Created", 201 },
+        { "CreatedAtAction", 201 },
+        { "CreatedAtRoute", 201 },
+        { "NoContent", 204 },
+        { "BadRequest", 400 },
+        { "Unauthorized", 401 },
+        { "Forbid", 403 },
+        { "NotFound", 404 },
+        { "Conflict", 409 },
+    };
+
     private void ExtractResponseType(MethodDeclarationSyntax method, RouteInfo route)
     {
         var returnType = method.ReturnType.ToString();
@@ -269,7 +307,38 @@ public class ControllerParser
         if (innerType == returnType)
             innerType = UnwrapGenericType(returnType, "IActionResult");
 
-        if (innerType == "void" || innerType == "IActionResult" || innerType == "ActionResult")
+        if (innerType != "void" && innerType != "IActionResult" && innerType != "ActionResult")
+        {
+            _visitedTypes.Clear();
+            var properties = ResolveTypeProperties(innerType);
+
+            route.Responses.Add(new ResponseInfo
+            {
+                Status = route.Method == "POST" ? 201 : 200,
+                Type = innerType,
+                Properties = properties,
+            });
+            return;
+        }
+
+        // For IActionResult/ActionResult, try to infer from return statements
+        var returnStatements = method.DescendantNodes().OfType<ReturnStatementSyntax>();
+        var seenStatuses = new HashSet<int>();
+
+        foreach (var ret in returnStatements)
+        {
+            if (ret.Expression is InvocationExpressionSyntax invocation)
+            {
+                var responseInfo = ExtractControllerResultInfo(invocation);
+                if (responseInfo != null && seenStatuses.Add(responseInfo.Status))
+                {
+                    route.Responses.Add(responseInfo);
+                }
+            }
+        }
+
+        // Fallback if no return statements found
+        if (route.Responses.Count == 0)
         {
             route.Responses.Add(new ResponseInfo
             {
@@ -277,18 +346,67 @@ public class ControllerParser
                 Type = null,
                 Properties = new List<Models.PropertyInfo>(),
             });
-            return;
+        }
+    }
+
+    private ResponseInfo? ExtractControllerResultInfo(InvocationExpressionSyntax invocation)
+    {
+        string methodName;
+
+        if (invocation.Expression is IdentifierNameSyntax identifier)
+        {
+            // Ok(...), NotFound(...), etc.
+            methodName = identifier.Identifier.Text;
+        }
+        else if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            // this.Ok(...), StatusCode(...)
+            methodName = memberAccess.Name.Identifier.Text;
+        }
+        else
+        {
+            return null;
         }
 
-        _visitedTypes.Clear();
-        var properties = ResolveTypeProperties(innerType);
+        if (!ResultMethodStatusCodes.TryGetValue(methodName, out var status))
+            return null;
 
-        route.Responses.Add(new ResponseInfo
+        // Try to resolve type from the first argument
+        string? typeName = null;
+        var properties = new List<Models.PropertyInfo>();
+
+        if (invocation.ArgumentList.Arguments.Count > 0)
         {
-            Status = route.Method == "POST" ? 201 : 200,
-            Type = innerType,
+            var firstArg = invocation.ArgumentList.Arguments[0].Expression;
+
+            // Try semantic model to get the type of the argument
+            if (_semanticModel != null)
+            {
+                var typeInfo = _semanticModel.GetTypeInfo(firstArg);
+                var argType = typeInfo.Type;
+
+                if (argType != null && argType.SpecialType == SpecialType.None
+                    && argType.TypeKind != TypeKind.Error
+                    && argType.Name != "Object")
+                {
+                    typeName = argType.Name;
+                    _visitedTypes.Clear();
+
+                    // Use type symbol directly for cross-project resolution
+                    if (argType is INamedTypeSymbol namedArgType)
+                        properties = ExtractPropertiesFromSymbol(namedArgType);
+                    else
+                        properties = ResolveTypeProperties(typeName);
+                }
+            }
+        }
+
+        return new ResponseInfo
+        {
+            Status = status,
+            Type = typeName,
             Properties = properties,
-        });
+        };
     }
 
     private static string UnwrapGenericType(string typeName, string wrapperName)
@@ -306,7 +424,26 @@ public class ControllerParser
         if (typeSyntax == null)
             return new List<Models.PropertyInfo>();
 
-        return ResolveTypeProperties(typeSyntax.ToString());
+        var typeName = typeSyntax.ToString();
+        if (IsPrimitiveType(typeName))
+            return new List<Models.PropertyInfo>();
+
+        // Try direct semantic resolution from syntax node (resolves cross-project types)
+        if (_semanticModel != null)
+        {
+            var typeInfo = _semanticModel.GetTypeInfo(typeSyntax);
+            if (typeInfo.Type is INamedTypeSymbol namedType
+                && namedType.TypeKind != TypeKind.Error
+                && !_visitedTypes.Contains(typeName))
+            {
+                _visitedTypes.Add(typeName);
+                var props = ExtractPropertiesFromSymbol(namedType);
+                if (props.Count > 0)
+                    return props;
+            }
+        }
+
+        return ResolveTypeProperties(typeName);
     }
 
     private List<Models.PropertyInfo> ResolveTypeProperties(string typeName)
@@ -340,19 +477,22 @@ public class ControllerParser
 
     private List<Models.PropertyInfo> ResolveViaSemanticModel(string typeName)
     {
-        var properties = new List<Models.PropertyInfo>();
-
         var compilation = _semanticModel!.Compilation;
         var typeSymbol = compilation.GetTypeByMetadataName(typeName);
 
-        // If not found by full name, search all types
+        // If not found by full name, search all types in source
         if (typeSymbol == null)
-        {
             typeSymbol = FindTypeByShortName(compilation, typeName);
-        }
 
         if (typeSymbol == null)
-            return properties;
+            return new List<Models.PropertyInfo>();
+
+        return ExtractPropertiesFromSymbol(typeSymbol);
+    }
+
+    private static List<Models.PropertyInfo> ExtractPropertiesFromSymbol(INamedTypeSymbol typeSymbol)
+    {
+        var properties = new List<Models.PropertyInfo>();
 
         foreach (var member in typeSymbol.GetMembers())
         {
@@ -368,11 +508,16 @@ public class ControllerParser
             var propType = propSymbol.Type;
             var isNullable = propType.NullableAnnotation == NullableAnnotation.Annotated;
 
+            // Check [Required] attribute or C# required keyword
+            var hasRequiredAttr = propSymbol.GetAttributes()
+                .Any(a => a.AttributeClass?.Name is "RequiredAttribute" or "Required");
+            var isRequired = propSymbol.IsRequired || hasRequiredAttr;
+
             properties.Add(new Models.PropertyInfo
             {
                 Name = ToCamelCase(propSymbol.Name),
                 Type = MapRoslynTypeToJsonType(propType),
-                Required = !isNullable && propType.IsValueType,
+                Required = isRequired || (!isNullable && propType.IsValueType),
             });
         }
 

--- a/analyzer/Parsers/MinimalApiParser.cs
+++ b/analyzer/Parsers/MinimalApiParser.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -67,6 +68,9 @@ public class MinimalApiParser
             if (!routePath.StartsWith("/"))
                 routePath = "/" + routePath;
 
+            // Strip route constraints: {id:guid} → {id}
+            routePath = Regex.Replace(routePath, @"\{(\w+):[^}]+\}", "{$1}");
+
             var route = new RouteInfo
             {
                 Path = routePath,
@@ -112,6 +116,12 @@ public class MinimalApiParser
         }
     }
 
+    private static readonly HashSet<string> FormFileTypes = new()
+    {
+        "IFormFile", "IFormFileCollection", "IFormFile?",
+        "List<IFormFile>", "IList<IFormFile>", "IEnumerable<IFormFile>",
+    };
+
     private void ExtractLambdaParams(ParameterListSyntax parameterList, RouteInfo route)
     {
         foreach (var param in parameterList.Parameters)
@@ -124,10 +134,25 @@ public class MinimalApiParser
             if (source == "service")
                 continue;
 
+            // IFormFile → multipart/form-data
+            if (FormFileTypes.Contains(paramType))
+            {
+                route.RequestBody = new RequestBodyInfo
+                {
+                    Type = paramType,
+                    ContentType = "multipart/form-data",
+                    Properties = new List<Models.PropertyInfo>
+                    {
+                        new() { Name = paramName, Type = "binary", Required = true },
+                    },
+                };
+                continue;
+            }
+
             if (source == "body")
             {
                 _visitedTypes.Clear();
-                var properties = ResolveTypeProperties(paramType);
+                var properties = ResolveTypePropertiesFromSyntax(param.Type);
                 route.RequestBody = new RequestBodyInfo
                 {
                     Type = paramType,
@@ -144,6 +169,33 @@ public class MinimalApiParser
                 Required = param.Default == null && !paramType.EndsWith("?"),
             });
         }
+    }
+
+    private List<Models.PropertyInfo> ResolveTypePropertiesFromSyntax(TypeSyntax? typeSyntax)
+    {
+        if (typeSyntax == null)
+            return new List<Models.PropertyInfo>();
+
+        var typeName = typeSyntax.ToString();
+        if (IsPrimitiveType(typeName))
+            return new List<Models.PropertyInfo>();
+
+        // Try direct semantic resolution from syntax node (resolves cross-project types)
+        if (_semanticModel != null)
+        {
+            var typeInfo = _semanticModel.GetTypeInfo(typeSyntax);
+            if (typeInfo.Type is INamedTypeSymbol namedType
+                && namedType.TypeKind != TypeKind.Error
+                && !_visitedTypes.Contains(typeName))
+            {
+                _visitedTypes.Add(typeName);
+                var props = ExtractPropertiesFromSymbol(namedType);
+                if (props.Count > 0)
+                    return props;
+            }
+        }
+
+        return ResolveTypeProperties(typeName);
     }
 
     private void ExtractSimpleLambdaParam(ParameterSyntax param, RouteInfo route)
@@ -481,15 +533,21 @@ public class MinimalApiParser
 
     private List<Models.PropertyInfo> ResolveViaSemanticModel(string typeName)
     {
-        var properties = new List<Models.PropertyInfo>();
         var compilation = _semanticModel!.Compilation;
-
         var typeSymbol = compilation.GetTypeByMetadataName(typeName);
+
         if (typeSymbol == null)
             typeSymbol = FindTypeByShortName(compilation, typeName);
 
         if (typeSymbol == null)
-            return properties;
+            return new List<Models.PropertyInfo>();
+
+        return ExtractPropertiesFromSymbol(typeSymbol);
+    }
+
+    private static List<Models.PropertyInfo> ExtractPropertiesFromSymbol(INamedTypeSymbol typeSymbol)
+    {
+        var properties = new List<Models.PropertyInfo>();
 
         foreach (var member in typeSymbol.GetMembers())
         {
@@ -505,11 +563,15 @@ public class MinimalApiParser
             var propType = propSymbol.Type;
             var isNullable = propType.NullableAnnotation == NullableAnnotation.Annotated;
 
+            var hasRequiredAttr = propSymbol.GetAttributes()
+                .Any(a => a.AttributeClass?.Name is "RequiredAttribute" or "Required");
+            var isRequired = propSymbol.IsRequired || hasRequiredAttr;
+
             properties.Add(new Models.PropertyInfo
             {
                 Name = ToCamelCase(propSymbol.Name),
                 Type = MapRoslynTypeToJsonType(propType),
-                Required = !isNullable && propType.IsValueType,
+                Required = isRequired || (!isNullable && propType.IsValueType),
             });
         }
 

--- a/analyzer/Program.cs
+++ b/analyzer/Program.cs
@@ -163,11 +163,27 @@ public static class Program
             }
         };
 
+        // Track already-loaded project paths to avoid "already part of workspace" errors.
+        // When MSBuild opens a project, it automatically loads referenced projects too.
+        var loadedProjectPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var csprojPath in csprojFiles)
         {
+            // Skip if this project was already loaded as a dependency of another project
+            if (loadedProjectPaths.Contains(Path.GetFullPath(csprojPath)))
+                continue;
+
             try
             {
                 var project = await workspace.OpenProjectAsync(csprojPath);
+
+                // Record all projects now in the workspace (includes transitive references)
+                foreach (var p in workspace.CurrentSolution.Projects)
+                {
+                    if (!string.IsNullOrEmpty(p.FilePath))
+                        loadedProjectPaths.Add(Path.GetFullPath(p.FilePath));
+                }
+
                 var compilation = await project.GetCompilationAsync();
 
                 if (compilation == null)

--- a/scripts/test-parser.ts
+++ b/scripts/test-parser.ts
@@ -33,6 +33,11 @@ async function main() {
       parseResult = parseNestRoutes(repoPath);
       break;
     }
+    case "nextjs": {
+      const { parseNextRoutes } = await import("../src/parser/nextParser");
+      parseResult = await parseNextRoutes(repoPath);
+      break;
+    }
     case "aspnet-controller":
     case "aspnet-minimal":
     case "aspnet-both": {

--- a/src/detector/frameworkDetector.ts
+++ b/src/detector/frameworkDetector.ts
@@ -6,6 +6,7 @@ import { logger } from "../utils/logger";
 export enum Framework {
   EXPRESS = "express",
   NESTJS = "nestjs",
+  NEXTJS = "nextjs",
   ASPNET_CONTROLLER = "aspnet-controller",
   ASPNET_MINIMAL = "aspnet-minimal",
   ASPNET_BOTH = "aspnet-both",
@@ -25,6 +26,7 @@ export async function detectFramework(
     const mapping: Record<string, Framework> = {
       express: Framework.EXPRESS,
       nestjs: Framework.NESTJS,
+      nextjs: Framework.NEXTJS,
       aspnet: Framework.ASPNET_CONTROLLER,
       "aspnet-controller": Framework.ASPNET_CONTROLLER,
       "aspnet-minimal": Framework.ASPNET_MINIMAL,
@@ -49,6 +51,10 @@ export async function detectFramework(
       if (allDeps["@nestjs/core"]) {
         logger.info("Detected NestJS framework");
         return Framework.NESTJS;
+      }
+      if (allDeps["next"]) {
+        logger.info("Detected Next.js framework");
+        return Framework.NEXTJS;
       }
       if (allDeps["express"]) {
         logger.info("Detected Express framework");

--- a/src/generator/openApiGenerator.ts
+++ b/src/generator/openApiGenerator.ts
@@ -43,6 +43,13 @@ function mapType(type: string): string {
   return TYPE_MAP[type.toLowerCase()] ?? "string";
 }
 
+/**
+ * Strip ASP.NET route constraints from path: {id:guid} → {id}
+ */
+function stripRouteConstraints(path: string): string {
+  return path.replace(/\{(\w+):[^}]+\}/g, "{$1}");
+}
+
 function buildOperationId(
   controller: string | null,
   method: string,
@@ -52,7 +59,8 @@ function buildOperationId(
     ? controller.replace(/Controller$/i, "")
     : "default";
 
-  const pathPart = path
+  const cleanPath = stripRouteConstraints(path);
+  const pathPart = cleanPath
     .split("/")
     .filter((seg) => seg.length > 0)
     .map((seg) => {
@@ -121,6 +129,31 @@ function addRequestBodySchema(
   }
 
   const rb = route.requestBody;
+  const contentType = rb.contentType || "application/json";
+
+  // multipart/form-data (file upload)
+  if (contentType === "multipart/form-data") {
+    const formProps: Record<string, unknown> = {};
+    for (const prop of rb.properties) {
+      formProps[prop.name] =
+        prop.type === "binary"
+          ? { type: "string", format: "binary" }
+          : { type: mapType(prop.type) };
+    }
+
+    return {
+      required: true,
+      content: {
+        "multipart/form-data": {
+          schema: {
+            type: "object",
+            properties: formProps,
+          },
+        },
+      },
+    };
+  }
+
   const name = schemaName(route.controller, rb.type);
 
   if (!spec.components.schemas[name]) {
@@ -275,7 +308,7 @@ export function generateOpenApiSpec(
   };
 
   for (const route of parseResult.routes) {
-    const pathKey = route.path;
+    const pathKey = stripRouteConstraints(route.path);
     const methodKey = route.method.toLowerCase();
 
     if (!spec.paths[pathKey]) {

--- a/src/parser/dotnetBridge.ts
+++ b/src/parser/dotnetBridge.ts
@@ -22,6 +22,7 @@ interface DotnetRouteInfo {
   }>;
   requestBody: {
     type: string;
+    contentType?: string;
     properties: Array<{
       name: string;
       type: string;
@@ -161,6 +162,7 @@ export async function parseDotnet(repoPath: string): Promise<ParseResult> {
       requestBody: r.requestBody
         ? {
             type: r.requestBody.type,
+            contentType: r.requestBody.contentType,
             properties: r.requestBody.properties.map(
               (prop): PropertyInfo => ({
                 name: prop.name,

--- a/src/parser/nextParser.ts
+++ b/src/parser/nextParser.ts
@@ -1,0 +1,840 @@
+import fs from "fs";
+import path from "path";
+import * as babelParser from "@babel/parser";
+import _traverse from "@babel/traverse";
+import type { Node, Comment } from "@babel/types";
+import {
+  ParseResult,
+  RouteInfo,
+  ParseError,
+  HttpMethod,
+  ParamInfo,
+  RequestBodyInfo,
+  PropertyInfo,
+} from "./types";
+import { logger } from "../utils/logger";
+
+const traverse: typeof _traverse =
+  typeof _traverse === "function"
+    ? _traverse
+    : (_traverse as unknown as { default: typeof _traverse }).default;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HTTP_METHODS: Set<string> = new Set([
+  "GET",
+  "POST",
+  "PUT",
+  "DELETE",
+  "PATCH",
+  "HEAD",
+  "OPTIONS",
+]);
+
+const EXCLUDED_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  "test",
+  "__tests__",
+]);
+
+const BABEL_PLUGINS: babelParser.ParserPlugin[] = [
+  "typescript",
+  "jsx",
+  "decorators-legacy",
+  "classProperties",
+  "optionalChaining",
+  "nullishCoalescingOperator",
+];
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+type RouterType = "app" | "pages";
+
+interface NextRouteFile {
+  filePath: string;
+  routerType: RouterType;
+  routePath: string;
+}
+
+/**
+ * Find Next.js API route files in the repo.
+ * Supports both App Router and Pages Router.
+ */
+function discoverNextRouteFiles(rootDir: string): NextRouteFile[] {
+  const results: NextRouteFile[] = [];
+
+  // Possible root prefixes: root, src/
+  const prefixes = ["", "src/"];
+
+  for (const prefix of prefixes) {
+    // App Router: app/**/route.ts|js
+    const appDir = path.join(rootDir, prefix, "app");
+    if (fs.existsSync(appDir)) {
+      walkAppRouter(appDir, appDir, results);
+    }
+
+    // Pages Router: pages/api/**/*.ts|js
+    const pagesApiDir = path.join(rootDir, prefix, "pages", "api");
+    if (fs.existsSync(pagesApiDir)) {
+      walkPagesRouter(pagesApiDir, pagesApiDir, results);
+    }
+  }
+
+  return results;
+}
+
+function walkAppRouter(
+  dir: string,
+  appRoot: string,
+  results: NextRouteFile[]
+): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!EXCLUDED_DIRS.has(entry.name)) {
+        walkAppRouter(path.join(dir, entry.name), appRoot, results);
+      }
+    } else if (entry.isFile()) {
+      const name = entry.name;
+      // Only route.ts, route.js, route.tsx, route.jsx
+      if (/^route\.(ts|js|tsx|jsx)$/.test(name)) {
+        const filePath = path.join(dir, name);
+        const relativeDirPath = path.relative(appRoot, dir).replace(/\\/g, "/");
+        const routePath = filePathToRoutePath(relativeDirPath, "app");
+
+        // Only include routes under /api
+        if (routePath.startsWith("/api")) {
+          results.push({ filePath, routerType: "app", routePath });
+        }
+      }
+    }
+  }
+}
+
+function walkPagesRouter(
+  dir: string,
+  pagesApiRoot: string,
+  results: NextRouteFile[]
+): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!EXCLUDED_DIRS.has(entry.name)) {
+        walkPagesRouter(path.join(dir, entry.name), pagesApiRoot, results);
+      }
+    } else if (entry.isFile()) {
+      const name = entry.name;
+      if (
+        (name.endsWith(".ts") || name.endsWith(".js") ||
+         name.endsWith(".tsx") || name.endsWith(".jsx")) &&
+        !name.endsWith(".test.ts") &&
+        !name.endsWith(".test.js") &&
+        !name.endsWith(".spec.ts") &&
+        !name.endsWith(".spec.js") &&
+        !name.endsWith(".d.ts")
+      ) {
+        const filePath = path.join(dir, name);
+        const relativeFilePath = path
+          .relative(pagesApiRoot, filePath)
+          .replace(/\\/g, "/");
+        const routePath = filePathToRoutePath(relativeFilePath, "pages");
+        results.push({ filePath, routerType: "pages", routePath });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File path → Route path conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a file/directory path to an API route path.
+ *
+ * App Router:  "api/users/[id]"     → "/api/users/:id"
+ * Pages Router: "users/[id].ts"     → "/api/users/:id"
+ */
+function filePathToRoutePath(relativePath: string, routerType: RouterType): string {
+  let segments: string[];
+
+  if (routerType === "pages") {
+    // Remove file extension
+    const withoutExt = relativePath.replace(/\.(ts|js|tsx|jsx)$/, "");
+    segments = withoutExt.split("/");
+    // Remove trailing "index"
+    if (segments.length > 0 && segments[segments.length - 1] === "index") {
+      segments.pop();
+    }
+    // Prepend /api since pages/api/ is the root
+    segments = ["api", ...segments];
+  } else {
+    // App Router: relativePath is the directory path from app root
+    segments = relativePath.split("/").filter((s) => s !== "");
+  }
+
+  // Transform segments
+  const transformed = segments
+    .filter((s) => s !== "")
+    .map((segment) => {
+      // Strip route groups: (admin) → skip
+      if (/^\(.*\)$/.test(segment)) {
+        return null;
+      }
+      // Catch-all: [...slug] → :slug*
+      if (/^\[\.\.\.(\w+)\]$/.test(segment)) {
+        const match = segment.match(/^\[\.\.\.(\w+)\]$/);
+        return `:${match![1]}*`;
+      }
+      // Optional catch-all: [[...slug]] → :slug*
+      if (/^\[\[\.\.\.(\w+)\]\]$/.test(segment)) {
+        const match = segment.match(/^\[\[\.\.\.(\w+)\]\]$/);
+        return `:${match![1]}*`;
+      }
+      // Dynamic segment: [id] → :id
+      if (/^\[(\w+)\]$/.test(segment)) {
+        const match = segment.match(/^\[(\w+)\]$/);
+        return `:${match![1]}`;
+      }
+      return segment;
+    })
+    .filter((s): s is string => s !== null);
+
+  return "/" + transformed.join("/");
+}
+
+/**
+ * Extract path params from a converted route path (e.g. /api/users/:id).
+ */
+function extractPathParams(routePath: string): ParamInfo[] {
+  const params: ParamInfo[] = [];
+  const regex = /:([a-zA-Z_]\w*)(\*)?/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(routePath)) !== null) {
+    params.push({
+      name: match[1],
+      in: "path",
+      type: match[2] ? "string[]" : "string",
+      required: true,
+    });
+  }
+  return params;
+}
+
+// ---------------------------------------------------------------------------
+// AST helpers
+// ---------------------------------------------------------------------------
+
+function parseCode(code: string, fileName: string): any | null {
+  try {
+    return babelParser.parse(code, {
+      sourceType: "module",
+      plugins: BABEL_PLUGINS,
+      errorRecovery: true,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function getLeadingJSDoc(node: Node): string | null {
+  const comments: Comment[] | undefined | null = (node as any).leadingComments;
+  if (!comments || comments.length === 0) return null;
+
+  for (let i = comments.length - 1; i >= 0; i--) {
+    const c = comments[i];
+    if (c.type === "CommentBlock" && c.value.startsWith("*")) {
+      const cleaned = c.value
+        .replace(/^\*\s?/gm, "")
+        .replace(/\n\s*\*/g, "\n")
+        .replace(/^\s+|\s+$/g, "")
+        .trim();
+      return cleaned || null;
+    }
+  }
+  return null;
+}
+
+function wrapInProgram(node: Node): any {
+  return {
+    type: "File",
+    program: {
+      type: "Program",
+      sourceType: "module",
+      body: [
+        {
+          type: "ExpressionStatement",
+          expression: node,
+        },
+      ],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// App Router parser: extract named exports (GET, POST, etc.)
+// ---------------------------------------------------------------------------
+
+function parseAppRouterFile(
+  code: string,
+  routePath: string,
+  source: string
+): { routes: RouteInfo[]; errors: ParseError[] } {
+  const routes: RouteInfo[] = [];
+  const errors: ParseError[] = [];
+
+  const ast = parseCode(code, source);
+  if (!ast) {
+    errors.push({ file: source, reason: "Failed to parse file" });
+    return { routes, errors };
+  }
+
+  const pathParams = extractPathParams(routePath);
+
+  traverse(ast, {
+    // export async function GET(request) { ... }
+    ExportNamedDeclaration(p: any) {
+      const decl = p.node.declaration;
+      if (!decl) return;
+
+      if (decl.type === "FunctionDeclaration" && decl.id?.name) {
+        const method = decl.id.name.toUpperCase();
+        if (!HTTP_METHODS.has(method)) return;
+
+        const description = getLeadingJSDoc(p.node) || getLeadingJSDoc(decl);
+        const requestBody = extractAppRouterBody(decl);
+        const queryParams = extractAppRouterSearchParams(decl);
+
+        routes.push({
+          path: routePath,
+          method: method as HttpMethod,
+          controller: decl.id.name,
+          routePrefix: null,
+          params: [...pathParams, ...queryParams],
+          requestBody,
+          responses: [],
+          auth: null,
+          middleware: [],
+          description,
+          source,
+        });
+      }
+
+      // export const GET = async (request) => { ... }
+      if (decl.type === "VariableDeclaration") {
+        for (const declarator of decl.declarations) {
+          if (declarator.id?.type !== "Identifier") continue;
+          const method = declarator.id.name.toUpperCase();
+          if (!HTTP_METHODS.has(method)) return;
+
+          const init = declarator.init;
+          if (!init) continue;
+
+          // Arrow function or function expression
+          const fnNode =
+            init.type === "ArrowFunctionExpression" ||
+            init.type === "FunctionExpression"
+              ? init
+              : null;
+
+          const description = getLeadingJSDoc(p.node) || getLeadingJSDoc(decl);
+          const requestBody = fnNode ? extractAppRouterBody(fnNode) : null;
+          const queryParams = fnNode ? extractAppRouterSearchParams(fnNode) : [];
+
+          routes.push({
+            path: routePath,
+            method: method as HttpMethod,
+            controller: declarator.id.name,
+            routePrefix: null,
+            params: [...pathParams, ...queryParams],
+            requestBody,
+            responses: [],
+            auth: null,
+            middleware: [],
+            description,
+            source,
+          });
+        }
+      }
+    },
+  });
+
+  return { routes, errors };
+}
+
+/**
+ * Detect request.json() calls in App Router handler body.
+ */
+function extractAppRouterBody(fnNode: Node): RequestBodyInfo | null {
+  let hasBody = false;
+
+  traverse(
+    wrapInProgram(fnNode),
+    {
+      CallExpression(innerPath: any) {
+        const node = innerPath.node;
+        // request.json() or req.json()
+        if (
+          node.callee?.type === "MemberExpression" &&
+          node.callee.property?.type === "Identifier" &&
+          node.callee.property.name === "json" &&
+          node.callee.object?.type === "Identifier"
+        ) {
+          hasBody = true;
+        }
+        // (await request.json()) pattern — already caught by above
+      },
+    },
+    undefined,
+    { noScope: true }
+  );
+
+  return hasBody ? { type: "object", properties: [] } : null;
+}
+
+/**
+ * Detect searchParams / nextUrl.searchParams usage in App Router.
+ */
+function extractAppRouterSearchParams(fnNode: Node): ParamInfo[] {
+  const params: ParamInfo[] = [];
+  const seen = new Set<string>();
+
+  traverse(
+    wrapInProgram(fnNode),
+    {
+      CallExpression(innerPath: any) {
+        const node = innerPath.node;
+        // searchParams.get('name') or request.nextUrl.searchParams.get('name')
+        if (
+          node.callee?.type === "MemberExpression" &&
+          node.callee.property?.type === "Identifier" &&
+          node.callee.property.name === "get" &&
+          node.arguments?.length >= 1 &&
+          node.arguments[0].type === "StringLiteral"
+        ) {
+          // Check if the object involves searchParams
+          if (isSearchParamsAccess(node.callee.object)) {
+            const paramName = node.arguments[0].value;
+            if (!seen.has(paramName)) {
+              seen.add(paramName);
+              params.push({
+                name: paramName,
+                in: "query",
+                type: "string",
+                required: false,
+              });
+            }
+          }
+        }
+      },
+    },
+    undefined,
+    { noScope: true }
+  );
+
+  return params;
+}
+
+function isSearchParamsAccess(node: any): boolean {
+  if (!node) return false;
+  // searchParams (direct variable)
+  if (node.type === "Identifier" && node.name === "searchParams") return true;
+  // *.searchParams
+  if (
+    node.type === "MemberExpression" &&
+    node.property?.type === "Identifier" &&
+    node.property.name === "searchParams"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Pages Router parser: detect methods from default export handler
+// ---------------------------------------------------------------------------
+
+function parsePagesRouterFile(
+  code: string,
+  routePath: string,
+  source: string
+): { routes: RouteInfo[]; errors: ParseError[] } {
+  const routes: RouteInfo[] = [];
+  const errors: ParseError[] = [];
+
+  const ast = parseCode(code, source);
+  if (!ast) {
+    errors.push({ file: source, reason: "Failed to parse file" });
+    return { routes, errors };
+  }
+
+  const pathParams = extractPathParams(routePath);
+
+  // Find the default export handler function
+  let handlerNode: any = null;
+  let handlerDescription: string | null = null;
+
+  traverse(ast, {
+    ExportDefaultDeclaration(p: any) {
+      const decl = p.node.declaration;
+      handlerDescription = getLeadingJSDoc(p.node);
+
+      if (
+        decl.type === "FunctionDeclaration" ||
+        decl.type === "ArrowFunctionExpression" ||
+        decl.type === "FunctionExpression"
+      ) {
+        handlerNode = decl;
+      } else if (decl.type === "Identifier") {
+        // export default handler — need to find the handler declaration
+        const name = decl.name;
+        // Look for function declaration or variable with that name
+        p.scope?.path?.traverse({
+          FunctionDeclaration(fp: any) {
+            if (fp.node.id?.name === name) {
+              handlerNode = fp.node;
+            }
+          },
+          VariableDeclarator(vp: any) {
+            if (
+              vp.node.id?.type === "Identifier" &&
+              vp.node.id.name === name &&
+              (vp.node.init?.type === "ArrowFunctionExpression" ||
+                vp.node.init?.type === "FunctionExpression")
+            ) {
+              handlerNode = vp.node.init;
+            }
+          },
+        });
+      }
+    },
+  });
+
+  if (!handlerNode) {
+    errors.push({
+      file: source,
+      reason: "No default export handler found",
+    });
+    return { routes, errors };
+  }
+
+  // Detect methods from req.method checks
+  const methods = extractMethodsFromHandler(handlerNode);
+
+  // Extract query params and body
+  const queryParams = extractPagesQueryParams(handlerNode);
+  const requestBody = extractPagesRequestBody(handlerNode);
+
+  // Get handler name
+  const controller = handlerNode.id?.name ?? null;
+
+  if (methods.length === 0) {
+    // No method checks found — treat as handling all methods (default: GET)
+    routes.push({
+      path: routePath,
+      method: "GET",
+      controller,
+      routePrefix: null,
+      params: [...pathParams, ...queryParams],
+      requestBody,
+      responses: [],
+      auth: null,
+      middleware: [],
+      description: handlerDescription,
+      source,
+    });
+  } else {
+    for (const method of methods) {
+      // Only attach body for methods that use it
+      const methodBody =
+        method === "POST" || method === "PUT" || method === "PATCH"
+          ? requestBody
+          : null;
+
+      routes.push({
+        path: routePath,
+        method,
+        controller,
+        routePrefix: null,
+        params: [...pathParams, ...queryParams],
+        requestBody: methodBody,
+        responses: [],
+        auth: null,
+        middleware: [],
+        description: handlerDescription,
+        source,
+      });
+    }
+  }
+
+  return { routes, errors };
+}
+
+/**
+ * Extract HTTP methods from `req.method === 'GET'` or `req.method === 'POST'` checks.
+ */
+function extractMethodsFromHandler(handlerNode: Node): HttpMethod[] {
+  const methods = new Set<HttpMethod>();
+
+  traverse(
+    wrapInProgram(handlerNode),
+    {
+      // req.method === 'GET'
+      BinaryExpression(innerPath: any) {
+        const node = innerPath.node;
+        if (node.operator !== "===" && node.operator !== "==") return;
+
+        const isMethodLeft = isReqMethodAccess(node.left);
+        const isMethodRight = isReqMethodAccess(node.right);
+
+        if (isMethodLeft && node.right?.type === "StringLiteral") {
+          const m = node.right.value.toUpperCase();
+          if (HTTP_METHODS.has(m)) methods.add(m as HttpMethod);
+        }
+        if (isMethodRight && node.left?.type === "StringLiteral") {
+          const m = node.left.value.toUpperCase();
+          if (HTTP_METHODS.has(m)) methods.add(m as HttpMethod);
+        }
+      },
+      // switch (req.method) { case 'GET': ... }
+      SwitchStatement(innerPath: any) {
+        const node = innerPath.node;
+        if (!isReqMethodAccess(node.discriminant)) return;
+
+        for (const c of node.cases) {
+          if (c.test?.type === "StringLiteral") {
+            const m = c.test.value.toUpperCase();
+            if (HTTP_METHODS.has(m)) methods.add(m as HttpMethod);
+          }
+        }
+      },
+    },
+    undefined,
+    { noScope: true }
+  );
+
+  return Array.from(methods);
+}
+
+function isReqMethodAccess(node: any): boolean {
+  return (
+    node?.type === "MemberExpression" &&
+    node.object?.type === "Identifier" &&
+    node.object.name === "req" &&
+    node.property?.type === "Identifier" &&
+    node.property.name === "method"
+  );
+}
+
+/**
+ * Extract query params from `req.query.xxx` in Pages Router.
+ */
+function extractPagesQueryParams(handlerNode: Node): ParamInfo[] {
+  const params: ParamInfo[] = [];
+  const seen = new Set<string>();
+
+  traverse(
+    wrapInProgram(handlerNode),
+    {
+      MemberExpression(innerPath: any) {
+        const node = innerPath.node;
+        if (
+          node.object?.type === "MemberExpression" &&
+          node.object.object?.type === "Identifier" &&
+          node.object.object.name === "req" &&
+          node.object.property?.type === "Identifier" &&
+          node.object.property.name === "query"
+        ) {
+          let paramName: string | null = null;
+          if (node.property.type === "Identifier") {
+            paramName = node.property.name;
+          } else if (node.property.type === "StringLiteral") {
+            paramName = node.property.value;
+          }
+          if (paramName && !seen.has(paramName)) {
+            seen.add(paramName);
+            params.push({
+              name: paramName,
+              in: "query",
+              type: "string",
+              required: false,
+            });
+          }
+        }
+      },
+    },
+    undefined,
+    { noScope: true }
+  );
+
+  return params;
+}
+
+/**
+ * Extract request body from `req.body` in Pages Router.
+ */
+function extractPagesRequestBody(handlerNode: Node): RequestBodyInfo | null {
+  const properties: PropertyInfo[] = [];
+  const seen = new Set<string>();
+  let hasBody = false;
+
+  traverse(
+    wrapInProgram(handlerNode),
+    {
+      MemberExpression(innerPath: any) {
+        const node = innerPath.node;
+        if (
+          node.object?.type === "Identifier" &&
+          node.object.name === "req" &&
+          node.property?.type === "Identifier" &&
+          node.property.name === "body"
+        ) {
+          hasBody = true;
+        }
+        if (
+          node.object?.type === "MemberExpression" &&
+          node.object.object?.type === "Identifier" &&
+          node.object.object.name === "req" &&
+          node.object.property?.type === "Identifier" &&
+          node.object.property.name === "body"
+        ) {
+          let propName: string | null = null;
+          if (node.property.type === "Identifier") {
+            propName = node.property.name;
+          } else if (node.property.type === "StringLiteral") {
+            propName = node.property.value;
+          }
+          if (propName && !seen.has(propName)) {
+            seen.add(propName);
+            properties.push({
+              name: propName,
+              type: "any",
+              required: false,
+            });
+          }
+        }
+      },
+      // const { name, email } = req.body
+      VariableDeclarator(innerPath: any) {
+        const node = innerPath.node;
+        if (
+          node.id?.type === "ObjectPattern" &&
+          node.init?.type === "MemberExpression" &&
+          node.init.object?.type === "Identifier" &&
+          node.init.object.name === "req" &&
+          node.init.property?.type === "Identifier" &&
+          node.init.property.name === "body"
+        ) {
+          hasBody = true;
+          for (const prop of node.id.properties) {
+            if (
+              prop.type === "ObjectProperty" &&
+              prop.key?.type === "Identifier"
+            ) {
+              const propName = prop.key.name;
+              if (!seen.has(propName)) {
+                seen.add(propName);
+                properties.push({
+                  name: propName,
+                  type: "any",
+                  required: false,
+                });
+              }
+            }
+          }
+        }
+      },
+    },
+    undefined,
+    { noScope: true }
+  );
+
+  if (!hasBody && properties.length === 0) return null;
+  return { type: "object", properties };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function parseNextRoutes(
+  rootDir: string
+): Promise<ParseResult> {
+  const routes: RouteInfo[] = [];
+  const errors: ParseError[] = [];
+
+  const routeFiles = discoverNextRouteFiles(rootDir);
+  logger.info(
+    { fileCount: routeFiles.length, rootDir },
+    "Scanning Next.js API routes"
+  );
+
+  for (const routeFile of routeFiles) {
+    try {
+      const code = fs.readFileSync(routeFile.filePath, "utf-8");
+      const relativePath = path
+        .relative(rootDir, routeFile.filePath)
+        .replace(/\\/g, "/");
+
+      const result =
+        routeFile.routerType === "app"
+          ? parseAppRouterFile(code, routeFile.routePath, relativePath)
+          : parsePagesRouterFile(code, routeFile.routePath, relativePath);
+
+      routes.push(...result.routes);
+      errors.push(...result.errors);
+    } catch (err: any) {
+      errors.push({
+        file: path.relative(rootDir, routeFile.filePath).replace(/\\/g, "/"),
+        reason: `Failed to read file: ${err.message ?? err}`,
+      });
+    }
+  }
+
+  logger.info(
+    { routeCount: routes.length, errorCount: errors.length },
+    "Next.js route parsing complete"
+  );
+
+  return { routes, errors };
+}
+
+/**
+ * Parse an in-memory source string. Useful for testing.
+ */
+export function parseNextSource(
+  code: string,
+  filePath: string,
+  routerType: RouterType
+): ParseResult {
+  const routePath = filePathToRoutePath(
+    filePath,
+    routerType
+  );
+  const result =
+    routerType === "app"
+      ? parseAppRouterFile(code, routePath, filePath)
+      : parsePagesRouterFile(code, routePath, filePath);
+  return { routes: result.routes, errors: result.errors };
+}
+
+// Export for testing
+export { filePathToRoutePath };

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -35,6 +35,7 @@ export interface ParamInfo {
 
 export interface RequestBodyInfo {
   type: string;
+  contentType?: string;
   properties: PropertyInfo[];
 }
 

--- a/src/pipeline/processAnalysis.ts
+++ b/src/pipeline/processAnalysis.ts
@@ -154,6 +154,10 @@ async function parseByFramework(
       const { parseNestRoutes } = await import("../parser/nestParser");
       return parseNestRoutes(repoPath);
     }
+    case Framework.NEXTJS: {
+      const { parseNextRoutes } = await import("../parser/nextParser");
+      return parseNextRoutes(repoPath);
+    }
     case Framework.ASPNET_CONTROLLER:
     case Framework.ASPNET_MINIMAL:
     case Framework.ASPNET_BOTH: {

--- a/test/parser/nextParser.test.ts
+++ b/test/parser/nextParser.test.ts
@@ -1,0 +1,595 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import {
+  parseNextSource,
+  parseNextRoutes,
+  filePathToRoutePath,
+} from "../../src/parser/nextParser";
+
+// Mock logger
+jest.mock("../../src/utils/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  createChildLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseApp(code: string, filePath = "api/users") {
+  return parseNextSource(code, filePath, "app");
+}
+
+function parsePages(code: string, filePath = "users.ts") {
+  return parseNextSource(code, filePath, "pages");
+}
+
+// ---------------------------------------------------------------------------
+// 1. File path → Route path conversion
+// ---------------------------------------------------------------------------
+
+describe("nextParser", () => {
+  describe("filePathToRoutePath", () => {
+    it("should convert App Router paths", () => {
+      expect(filePathToRoutePath("api/users", "app")).toBe("/api/users");
+      expect(filePathToRoutePath("api/users/[id]", "app")).toBe(
+        "/api/users/:id"
+      );
+      expect(filePathToRoutePath("api/posts/[...slug]", "app")).toBe(
+        "/api/posts/:slug*"
+      );
+    });
+
+    it("should strip route groups", () => {
+      expect(filePathToRoutePath("(admin)/api/users", "app")).toBe(
+        "/api/users"
+      );
+      expect(
+        filePathToRoutePath("(auth)/(dashboard)/api/settings", "app")
+      ).toBe("/api/settings");
+    });
+
+    it("should convert Pages Router paths", () => {
+      expect(filePathToRoutePath("users.ts", "pages")).toBe("/api/users");
+      expect(filePathToRoutePath("users/index.ts", "pages")).toBe(
+        "/api/users"
+      );
+      expect(filePathToRoutePath("users/[id].ts", "pages")).toBe(
+        "/api/users/:id"
+      );
+    });
+
+    it("should handle catch-all routes", () => {
+      expect(filePathToRoutePath("api/[...slug]", "app")).toBe(
+        "/api/:slug*"
+      );
+      expect(filePathToRoutePath("[...slug].ts", "pages")).toBe(
+        "/api/:slug*"
+      );
+    });
+
+    it("should handle optional catch-all routes", () => {
+      expect(filePathToRoutePath("api/[[...slug]]", "app")).toBe(
+        "/api/:slug*"
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. App Router — named export functions
+  // ---------------------------------------------------------------------------
+
+  describe("App Router", () => {
+    it("should detect export async function GET", () => {
+      const result = parseApp(`
+        export async function GET(request: Request) {
+          return Response.json({ users: [] });
+        }
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].path).toBe("/api/users");
+      expect(result.routes[0].method).toBe("GET");
+      expect(result.routes[0].controller).toBe("GET");
+    });
+
+    it("should detect multiple method exports", () => {
+      const result = parseApp(`
+        export async function GET(request: Request) {
+          return Response.json([]);
+        }
+
+        export async function POST(request: Request) {
+          const body = await request.json();
+          return Response.json({ created: true });
+        }
+      `);
+
+      expect(result.routes).toHaveLength(2);
+      expect(result.routes.map((r) => r.method).sort()).toEqual([
+        "GET",
+        "POST",
+      ]);
+    });
+
+    it("should detect export const GET = arrow function", () => {
+      const result = parseApp(`
+        export const GET = async (request: Request) => {
+          return Response.json([]);
+        };
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].method).toBe("GET");
+      expect(result.routes[0].controller).toBe("GET");
+    });
+
+    it("should extract path params from dynamic route", () => {
+      const result = parseApp(
+        `
+        export async function GET(
+          request: Request,
+          { params }: { params: { id: string } }
+        ) {
+          return Response.json({ id: params.id });
+        }
+      `,
+        "api/users/[id]"
+      );
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].path).toBe("/api/users/:id");
+      expect(result.routes[0].params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "id",
+            in: "path",
+            required: true,
+          }),
+        ])
+      );
+    });
+
+    it("should detect request.json() as request body", () => {
+      const result = parseApp(`
+        export async function POST(request: Request) {
+          const body = await request.json();
+          return Response.json(body);
+        }
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].requestBody).not.toBeNull();
+      expect(result.routes[0].requestBody?.type).toBe("object");
+    });
+
+    it("should detect searchParams.get() as query params", () => {
+      const result = parseApp(`
+        export async function GET(request: Request) {
+          const { searchParams } = new URL(request.url);
+          const page = searchParams.get('page');
+          const limit = searchParams.get('limit');
+          return Response.json([]);
+        }
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      const queryParams = result.routes[0].params.filter(
+        (p) => p.in === "query"
+      );
+      expect(queryParams).toHaveLength(2);
+      expect(queryParams.map((p) => p.name).sort()).toEqual(["limit", "page"]);
+    });
+
+    it("should detect nextUrl.searchParams.get() as query params", () => {
+      const result = parseApp(`
+        export async function GET(request: NextRequest) {
+          const page = request.nextUrl.searchParams.get('page');
+          return Response.json([]);
+        }
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      const queryParams = result.routes[0].params.filter(
+        (p) => p.in === "query"
+      );
+      expect(queryParams).toHaveLength(1);
+      expect(queryParams[0].name).toBe("page");
+    });
+
+    it("should handle route groups by stripping them", () => {
+      const result = parseApp(
+        `
+        export async function GET() {
+          return Response.json([]);
+        }
+      `,
+        "(admin)/api/users"
+      );
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].path).toBe("/api/users");
+    });
+
+    it("should handle catch-all routes", () => {
+      const result = parseApp(
+        `
+        export async function GET(
+          request: Request,
+          { params }: { params: { slug: string[] } }
+        ) {
+          return Response.json({ slug: params.slug });
+        }
+      `,
+        "api/docs/[...slug]"
+      );
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].path).toBe("/api/docs/:slug*");
+      expect(result.routes[0].params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "slug",
+            in: "path",
+            type: "string[]",
+          }),
+        ])
+      );
+    });
+
+    it("should extract JSDoc description", () => {
+      const result = parseApp(`
+        /** List all users */
+        export async function GET(request: Request) {
+          return Response.json([]);
+        }
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].description).toBe("List all users");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Pages Router — default export handler
+  // ---------------------------------------------------------------------------
+
+  describe("Pages Router", () => {
+    it("should detect default export handler as GET", () => {
+      const result = parsePages(`
+        export default function handler(req, res) {
+          res.json({ users: [] });
+        }
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].path).toBe("/api/users");
+      expect(result.routes[0].method).toBe("GET");
+    });
+
+    it("should detect methods from req.method === checks", () => {
+      const result = parsePages(`
+        export default function handler(req, res) {
+          if (req.method === 'GET') {
+            res.json([]);
+          } else if (req.method === 'POST') {
+            res.status(201).json({});
+          }
+        }
+      `);
+
+      expect(result.routes).toHaveLength(2);
+      expect(result.routes.map((r) => r.method).sort()).toEqual([
+        "GET",
+        "POST",
+      ]);
+    });
+
+    it("should detect methods from switch statement", () => {
+      const result = parsePages(`
+        export default function handler(req, res) {
+          switch (req.method) {
+            case 'GET':
+              res.json([]);
+              break;
+            case 'POST':
+              res.status(201).json({});
+              break;
+            case 'DELETE':
+              res.status(204).end();
+              break;
+          }
+        }
+      `);
+
+      expect(result.routes).toHaveLength(3);
+      expect(result.routes.map((r) => r.method).sort()).toEqual([
+        "DELETE",
+        "GET",
+        "POST",
+      ]);
+    });
+
+    it("should extract path params from dynamic route", () => {
+      const result = parsePages(
+        `
+        export default function handler(req, res) {
+          const { id } = req.query;
+          res.json({ id });
+        }
+      `,
+        "users/[id].ts"
+      );
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].path).toBe("/api/users/:id");
+      expect(result.routes[0].params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "id",
+            in: "path",
+            required: true,
+          }),
+        ])
+      );
+    });
+
+    it("should extract req.query params", () => {
+      const result = parsePages(`
+        export default function handler(req, res) {
+          const page = req.query.page;
+          const limit = req.query.limit;
+          res.json([]);
+        }
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      const queryParams = result.routes[0].params.filter(
+        (p) => p.in === "query"
+      );
+      expect(queryParams).toHaveLength(2);
+      expect(queryParams.map((p) => p.name).sort()).toEqual(["limit", "page"]);
+    });
+
+    it("should extract req.body", () => {
+      const result = parsePages(`
+        export default function handler(req, res) {
+          if (req.method === 'POST') {
+            const { name, email } = req.body;
+            res.status(201).json({ name, email });
+          }
+        }
+      `);
+
+      const postRoute = result.routes.find((r) => r.method === "POST");
+      expect(postRoute).toBeDefined();
+      expect(postRoute!.requestBody).not.toBeNull();
+      expect(postRoute!.requestBody?.properties).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "name" }),
+          expect.objectContaining({ name: "email" }),
+        ])
+      );
+    });
+
+    it("should not attach request body to GET routes", () => {
+      const result = parsePages(`
+        export default function handler(req, res) {
+          if (req.method === 'GET') {
+            res.json([]);
+          } else if (req.method === 'POST') {
+            const data = req.body;
+            res.status(201).json(data);
+          }
+        }
+      `);
+
+      const getRoute = result.routes.find((r) => r.method === "GET");
+      expect(getRoute!.requestBody).toBeNull();
+
+      const postRoute = result.routes.find((r) => r.method === "POST");
+      expect(postRoute!.requestBody).not.toBeNull();
+    });
+
+    it("should handle arrow function default export", () => {
+      const result = parsePages(`
+        export default (req, res) => {
+          res.json([]);
+        };
+      `);
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].method).toBe("GET");
+    });
+
+    it("should handle index.ts files", () => {
+      const result = parsePages(
+        `
+        export default function handler(req, res) {
+          res.json([]);
+        }
+      `,
+        "users/index.ts"
+      );
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0].path).toBe("/api/users");
+    });
+
+    it("should report error when no default export found", () => {
+      const result = parsePages(`
+        function notExported(req, res) {
+          res.json([]);
+        }
+      `);
+
+      expect(result.routes).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].reason).toContain("No default export");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. File system integration (parseNextRoutes)
+  // ---------------------------------------------------------------------------
+
+  describe("parseNextRoutes - file system", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nextparser-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true });
+    });
+
+    it("should discover and parse App Router route files", () => {
+      // Create app/api/users/route.ts
+      const routeDir = path.join(tmpDir, "app", "api", "users");
+      fs.mkdirSync(routeDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(routeDir, "route.ts"),
+        `
+        export async function GET(request: Request) {
+          return Response.json([]);
+        }
+
+        export async function POST(request: Request) {
+          const body = await request.json();
+          return Response.json(body);
+        }
+      `
+      );
+
+      return parseNextRoutes(tmpDir).then((result) => {
+        expect(result.routes).toHaveLength(2);
+        expect(result.routes.map((r) => r.method).sort()).toEqual([
+          "GET",
+          "POST",
+        ]);
+        expect(result.routes[0].path).toBe("/api/users");
+      });
+    });
+
+    it("should discover and parse Pages Router files", () => {
+      // Create pages/api/users.ts
+      const pagesDir = path.join(tmpDir, "pages", "api");
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "users.ts"),
+        `
+        export default function handler(req, res) {
+          if (req.method === 'GET') {
+            res.json([]);
+          } else if (req.method === 'POST') {
+            res.status(201).json({});
+          }
+        }
+      `
+      );
+
+      return parseNextRoutes(tmpDir).then((result) => {
+        expect(result.routes).toHaveLength(2);
+        expect(result.routes.map((r) => r.method).sort()).toEqual([
+          "GET",
+          "POST",
+        ]);
+      });
+    });
+
+    it("should discover routes under src/ prefix", () => {
+      // Create src/app/api/health/route.ts
+      const routeDir = path.join(tmpDir, "src", "app", "api", "health");
+      fs.mkdirSync(routeDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(routeDir, "route.ts"),
+        `
+        export async function GET() {
+          return Response.json({ status: 'ok' });
+        }
+      `
+      );
+
+      return parseNextRoutes(tmpDir).then((result) => {
+        expect(result.routes).toHaveLength(1);
+        expect(result.routes[0].path).toBe("/api/health");
+      });
+    });
+
+    it("should handle dynamic route directories", () => {
+      // Create app/api/users/[id]/route.ts
+      const routeDir = path.join(tmpDir, "app", "api", "users", "[id]");
+      fs.mkdirSync(routeDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(routeDir, "route.ts"),
+        `
+        export async function GET(
+          request: Request,
+          { params }: { params: { id: string } }
+        ) {
+          return Response.json({ id: params.id });
+        }
+
+        export async function DELETE(
+          request: Request,
+          { params }: { params: { id: string } }
+        ) {
+          return new Response(null, { status: 204 });
+        }
+      `
+      );
+
+      return parseNextRoutes(tmpDir).then((result) => {
+        expect(result.routes).toHaveLength(2);
+        expect(result.routes[0].path).toBe("/api/users/:id");
+        expect(result.routes[0].params).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: "id", in: "path" }),
+          ])
+        );
+      });
+    });
+
+    it("should exclude .next directory", () => {
+      // Create .next/server/app/api/users/route.ts (build output)
+      const buildDir = path.join(
+        tmpDir,
+        ".next",
+        "server",
+        "app",
+        "api",
+        "users"
+      );
+      fs.mkdirSync(buildDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(buildDir, "route.ts"),
+        `export async function GET() { return Response.json([]); }`
+      );
+
+      // Create actual source
+      const sourceDir = path.join(tmpDir, "app", "api", "users");
+      fs.mkdirSync(sourceDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sourceDir, "route.ts"),
+        `export async function GET() { return Response.json([]); }`
+      );
+
+      return parseNextRoutes(tmpDir).then((result) => {
+        expect(result.routes).toHaveLength(1);
+        expect(result.routes[0].source).not.toContain(".next");
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Next.js API Route Parser**: App Router (`export function GET/POST`) ve Pages Router (`export default` + `req.method`) destegi eklendi. Dinamik route (`[id]`), catch-all (`[...slug]`), route groups (`(group)`) ve `src/` prefix destekleniyor.
- **ASP.NET Analyzer Fixes**: Route constraint stripping (`{id:guid}` → `{id}`), IFormFile → `multipart/form-data`, cross-project DTO resolution, `[Required]` attribute destegi, response type extraction (`Ok()`, `NotFound()`, `NoContent()` vb.), duplicate proje yukleme hatasi duzeltildi.
- **OpenAPI Generator**: Constraint stripping, IFormFile content type, temiz operationId uretimi.

## Changed Files
| Dosya | Degisiklik |
|---|---|
| `src/parser/nextParser.ts` | Yeni Next.js parser (App Router + Pages Router) |
| `test/parser/nextParser.test.ts` | 30 test |
| `src/detector/frameworkDetector.ts` | NEXTJS enum + detection |
| `src/pipeline/processAnalysis.ts` | Pipeline'a Next.js case |
| `analyzer/Parsers/ControllerParser.cs` | Constraint strip, IFormFile, response extraction, cross-project DTO |
| `analyzer/Parsers/MinimalApiParser.cs` | Constraint strip, IFormFile, cross-project DTO |
| `analyzer/Models/RouteInfo.cs` | contentType field |
| `analyzer/Program.cs` | Duplicate proje yukleme fix |
| `analyzer/AutoDocAnalyzer.csproj` | ImplicitUsings enable |
| `src/generator/openApiGenerator.ts` | Constraint strip, multipart/form-data |
| `src/parser/types.ts` | contentType field |
| `src/parser/dotnetBridge.ts` | contentType mapping |
| `scripts/test-parser.ts` | Next.js case |

## Test plan
- [x] `npm run build` — 0 error
- [x] `dotnet build -c Release` — 0 error
- [x] `npm test` — 135/135 passed
- [x] docmind-api uzerinde test: 22 route, 0 error, tum DTO property'leri ve response tipleri dogru

🤖 Generated with [Claude Code](https://claude.com/claude-code)