### PR TITLE
feat: webhook installation handlers and event status tracking

### DIFF
--- a/src/api/webhookHandler.ts
+++ b/src/api/webhookHandler.ts
@@ -1,12 +1,13 @@
 import { Request, Response } from "express";
 import crypto from "crypto";
+import { eq } from "drizzle-orm";
 
 import { config } from "../config";
 import { logger } from "../utils/logger";
 import { checkRateLimit } from "../utils/rateLimiter";
 import { analysisQueue, QueueItem } from "../queue/analysisQueue";
 import { db } from "../db/connection";
-import { webhookEvents } from "../db/schema";
+import { webhookEvents, installations, repos } from "../db/schema";
 
 const log = logger.child({ module: "webhookHandler" });
 
@@ -45,16 +46,208 @@ export async function webhookHandler(req: Request, res: Response): Promise<void>
     return;
   }
 
-  // 2. Event filtering
+  // 2. Dispatch by event type
   const eventType = req.headers["x-github-event"] as string | undefined;
   const payload = req.body;
 
-  if (eventType !== "workflow_run") {
-    log.debug({ eventType }, "Ignoring non-workflow_run event");
-    res.status(200).json({ ignored: true, reason: "not a workflow_run event" });
+  switch (eventType) {
+    case "installation":
+      await handleInstallationEvent(payload, res);
+      return;
+
+    case "installation_repositories":
+      await handleInstallationRepositoriesEvent(payload, res);
+      return;
+
+    case "workflow_run":
+      await handleWorkflowRunEvent(eventType, payload, res);
+      return;
+
+    default:
+      log.debug({ eventType }, "Ignoring unhandled event type");
+      res.status(200).json({ ignored: true, reason: `unhandled event: ${eventType}` });
+      return;
+  }
+}
+
+/**
+ * Handle installation.created and installation.deleted events.
+ * Creates or removes installation and repo rows in the database.
+ */
+async function handleInstallationEvent(payload: any, res: Response): Promise<void> {
+  const action = payload.action;
+  const installationId: number | undefined = payload.installation?.id;
+  const owner: string | undefined = payload.installation?.account?.login;
+
+  if (!installationId || !owner) {
+    log.warn({ action }, "Malformed installation event payload");
+    res.status(400).json({ error: "Malformed payload" });
     return;
   }
 
+  if (action === "created") {
+    log.info({ installationId, owner }, "Processing installation.created");
+
+    try {
+      // Insert installation row
+      const [instRow] = await db
+        .insert(installations)
+        .values({
+          githubInstallationId: installationId,
+          owner,
+        })
+        .onConflictDoNothing({ target: installations.githubInstallationId })
+        .returning({ id: installations.id });
+
+      // If onConflictDoNothing returned nothing, look up existing row
+      let instDbId: number;
+      if (instRow) {
+        instDbId = instRow.id;
+      } else {
+        const [existing] = await db
+          .select({ id: installations.id })
+          .from(installations)
+          .where(eq(installations.githubInstallationId, installationId))
+          .limit(1);
+        instDbId = existing.id;
+      }
+
+      // Insert repos
+      const repositories: Array<{ name: string; full_name: string }> =
+        payload.repositories ?? [];
+
+      if (repositories.length > 0) {
+        await db.insert(repos).values(
+          repositories.map((r) => ({
+            installationId: instDbId,
+            repoName: r.name,
+            repoFullName: r.full_name,
+            isActive: "true" as const,
+          }))
+        );
+      }
+
+      log.info(
+        { installationId, owner, repoCount: repositories.length },
+        "Installation created with repos"
+      );
+      res.status(200).json({ processed: true, action: "installation.created" });
+    } catch (err) {
+      log.error({ err, installationId }, "Failed to process installation.created");
+      res.status(500).json({ error: "Failed to process installation event" });
+    }
+    return;
+  }
+
+  if (action === "deleted") {
+    log.info({ installationId, owner }, "Processing installation.deleted");
+
+    try {
+      // Look up installation to get internal ID for FK cascade
+      const [instRow] = await db
+        .select({ id: installations.id })
+        .from(installations)
+        .where(eq(installations.githubInstallationId, installationId))
+        .limit(1);
+
+      if (instRow) {
+        // Delete repos first (FK constraint)
+        await db.delete(repos).where(eq(repos.installationId, instRow.id));
+        // Delete installation
+        await db.delete(installations).where(eq(installations.id, instRow.id));
+      }
+
+      log.info({ installationId }, "Installation deleted");
+      res.status(200).json({ processed: true, action: "installation.deleted" });
+    } catch (err) {
+      log.error({ err, installationId }, "Failed to process installation.deleted");
+      res.status(500).json({ error: "Failed to process installation event" });
+    }
+    return;
+  }
+
+  // Other actions (e.g. suspend, unsuspend) — ignore
+  log.debug({ action }, "Ignoring installation action");
+  res.status(200).json({ ignored: true, reason: `unhandled installation action: ${action}` });
+}
+
+/**
+ * Handle installation_repositories.added and installation_repositories.removed events.
+ */
+async function handleInstallationRepositoriesEvent(
+  payload: any,
+  res: Response
+): Promise<void> {
+  const action = payload.action;
+  const installationId: number | undefined = payload.installation?.id;
+
+  if (!installationId) {
+    log.warn({ action }, "Malformed installation_repositories event payload");
+    res.status(400).json({ error: "Malformed payload" });
+    return;
+  }
+
+  try {
+    // Look up installation internal ID
+    const [instRow] = await db
+      .select({ id: installations.id })
+      .from(installations)
+      .where(eq(installations.githubInstallationId, installationId))
+      .limit(1);
+
+    if (!instRow) {
+      log.warn(
+        { installationId },
+        "Received repository event for unknown installation"
+      );
+      res.status(200).json({ ignored: true, reason: "unknown installation" });
+      return;
+    }
+
+    if (action === "added") {
+      const added: Array<{ name: string; full_name: string }> =
+        payload.repositories_added ?? [];
+
+      if (added.length > 0) {
+        await db.insert(repos).values(
+          added.map((r) => ({
+            installationId: instRow.id,
+            repoName: r.name,
+            repoFullName: r.full_name,
+            isActive: "true" as const,
+          }))
+        );
+      }
+
+      log.info({ installationId, count: added.length }, "Repositories added");
+    }
+
+    if (action === "removed") {
+      const removed: Array<{ full_name: string }> =
+        payload.repositories_removed ?? [];
+
+      for (const r of removed) {
+        await db.delete(repos).where(eq(repos.repoFullName, r.full_name));
+      }
+
+      log.info({ installationId, count: removed.length }, "Repositories removed");
+    }
+
+    res.status(200).json({ processed: true, action: `repositories.${action}` });
+  } catch (err) {
+    log.error({ err, installationId }, "Failed to process repository event");
+    res.status(500).json({ error: "Failed to process repository event" });
+  }
+}
+
+/**
+ * Handle workflow_run.completed events — the original analysis trigger.
+ */
+async function handleWorkflowRunEvent(
+  eventType: string,
+  payload: any,
+  res: Response
+): Promise<void> {
   if (payload.action !== "completed") {
     log.debug({ action: payload.action }, "Ignoring non-completed action");
     res.status(200).json({ ignored: true, reason: "action is not completed" });
@@ -70,7 +263,7 @@ export async function webhookHandler(req: Request, res: Response): Promise<void>
     return;
   }
 
-  // 3. Rate limit check
+  // Rate limit check
   const repoFullName: string = payload.repository.full_name;
 
   if (!checkRateLimit(repoFullName)) {
@@ -79,26 +272,33 @@ export async function webhookHandler(req: Request, res: Response): Promise<void>
     return;
   }
 
-  // 4. Save webhook event to DB
+  // Save webhook event to DB and capture ID for status tracking
+  let webhookEventId: number | undefined;
   try {
-    await db.insert(webhookEvents).values({
-      eventType: eventType,
-      action: payload.action,
-      repoFullName,
-      payload,
-      processed: "pending",
-    });
+    const [inserted] = await db
+      .insert(webhookEvents)
+      .values({
+        eventType: eventType,
+        action: payload.action,
+        repoFullName,
+        payload,
+        processed: "pending",
+      })
+      .returning({ id: webhookEvents.id });
+
+    webhookEventId = inserted?.id;
   } catch (err) {
     log.error({ err, repo: repoFullName }, "Failed to save webhook event to DB");
     // Continue processing even if DB write fails — the analysis is more important
   }
 
-  // 5. Enqueue analysis
+  // Enqueue analysis
   const item: QueueItem = {
     id: `${repoFullName}-${Date.now()}`,
     repoFullName,
     payload,
     addedAt: Date.now(),
+    webhookEventId,
   };
 
   analysisQueue.enqueue(item);

--- a/src/pipeline/processAnalysis.ts
+++ b/src/pipeline/processAnalysis.ts
@@ -10,11 +10,32 @@ import { loadAutodocConfig } from "../config/autodocConfig";
 import { detectFramework, Framework } from "../detector/frameworkDetector";
 import { generateOpenApiSpec } from "../generator/openApiGenerator";
 import { db } from "../db/connection";
-import { analyses, repos } from "../db/schema";
+import { analyses, repos, webhookEvents } from "../db/schema";
 import type { ParseResult } from "../parser/types";
+
+async function updateWebhookStatus(
+  webhookEventId: number | undefined,
+  status: "processing" | "done" | "skipped" | "error",
+  errorMessage?: string
+): Promise<void> {
+  if (!webhookEventId) return;
+  try {
+    await db
+      .update(webhookEvents)
+      .set({
+        processed: status,
+        processedAt: new Date(),
+        ...(errorMessage ? { errorMessage } : {}),
+      })
+      .where(eq(webhookEvents.id, webhookEventId));
+  } catch {
+    // Status tracking failure should not crash the pipeline
+  }
+}
 
 export async function processAnalysis(item: QueueItem): Promise<void> {
   const payload = item.payload as any;
+  const webhookEventId = item.webhookEventId;
 
   const owner: string = payload.repository.owner.login;
   const repo: string = payload.repository.name;
@@ -25,6 +46,7 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
   const startTime = Date.now();
 
   log.info("Starting analysis pipeline");
+  await updateWebhookStatus(webhookEventId, "processing");
 
   // 1. Permission check
   let token: string;
@@ -44,6 +66,7 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
       : "no push permission";
     log.warn({ reason }, "Skipping analysis due to permission restrictions");
 
+    await updateWebhookStatus(webhookEventId, "skipped");
     await saveAnalysis({
       owner,
       repo,
@@ -114,8 +137,16 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
       prUrl: prResult.prUrl,
       durationMs: Date.now() - startTime,
     });
+
+    await updateWebhookStatus(webhookEventId, "done");
   } catch (err) {
     log.error({ err }, "Analysis pipeline failed");
+
+    await updateWebhookStatus(
+      webhookEventId,
+      "error",
+      err instanceof Error ? err.message : String(err)
+    );
 
     await saveAnalysis({
       owner,

--- a/src/queue/analysisQueue.ts
+++ b/src/queue/analysisQueue.ts
@@ -6,6 +6,7 @@ export interface QueueItem {
   repoFullName: string;
   payload: unknown;
   addedAt: number;
+  webhookEventId?: number;
 }
 
 type ProcessFn = (item: QueueItem) => Promise<void>;


### PR DESCRIPTION
## Summary
- Add `installation.created` / `installation.deleted` webhook handlers to populate `installations` and `repos` tables (root cause of #5, #11)
- Add `installation_repositories.added` / `installation_repositories.removed` handlers for repo tracking
- Pass `webhookEventId` through queue to `processAnalysis` for status tracking
- Update `webhook_events.processed` status at each pipeline stage (`processing` → `done`/`error`/`skipped`)
- Refactor `webhookHandler` from linear flow to event-type dispatch pattern

## Test plan
- [ ] `npx tsc --noEmit` — zero type errors
- [ ] `npx jest` — all 135 tests pass
- [ ] Manual test: send mock `installation.created` payload, verify DB rows created
- [ ] Manual test: send mock `workflow_run` payload, verify `webhook_events.processed` transitions

Closes #16, Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)