### PR TITLE
fix: token cache upsert, repo fallback, and payload validation

### DIFF
--- a/src/github/appAuth.ts
+++ b/src/github/appAuth.ts
@@ -109,14 +109,29 @@ export async function getValidToken(installationId: number): Promise<string> {
     })
     .where(eq(installations.githubInstallationId, installationId));
 
-  // If no row was updated the installation may not exist in our DB yet.
-  // In that case, we still return the token but log a warning so the
-  // webhook handler can create the installation row when appropriate.
+  // If no row was updated, the installation may not exist in our DB yet.
+  // Use upsert as a safety net to create/update the row.
   if (!updateResult.rowCount || updateResult.rowCount === 0) {
     log.warn(
       { installationId },
-      "No installation row found in DB to cache token; token returned but not persisted"
+      "No installation row found; upserting token cache"
     );
+    await db
+      .insert(installations)
+      .values({
+        githubInstallationId: installationId,
+        owner: "unknown",
+        accessToken: newToken,
+        tokenExpiresAt: newExpiresAt,
+      })
+      .onConflictDoUpdate({
+        target: installations.githubInstallationId,
+        set: {
+          accessToken: newToken,
+          tokenExpiresAt: newExpiresAt,
+          updatedAt: new Date(),
+        },
+      });
   } else {
     log.info(
       { installationId, expiresAt: newExpiresAt.toISOString() },

--- a/src/pipeline/processAnalysis.ts
+++ b/src/pipeline/processAnalysis.ts
@@ -10,7 +10,7 @@ import { loadAutodocConfig } from "../config/autodocConfig";
 import { detectFramework, Framework } from "../detector/frameworkDetector";
 import { generateOpenApiSpec } from "../generator/openApiGenerator";
 import { db } from "../db/connection";
-import { analyses, repos, webhookEvents } from "../db/schema";
+import { analyses, installations, repos, webhookEvents } from "../db/schema";
 import type { ParseResult } from "../parser/types";
 
 async function updateWebhookStatus(
@@ -37,10 +37,20 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
   const payload = item.payload as any;
   const webhookEventId = item.webhookEventId;
 
-  const owner: string = payload.repository.owner.login;
-  const repo: string = payload.repository.name;
-  const installationId: number = payload.installation.id;
-  const commitSha: string = payload.workflow_run.head_sha;
+  const owner: string | undefined = payload?.repository?.owner?.login;
+  const repo: string | undefined = payload?.repository?.name;
+  const installationId: number | undefined = payload?.installation?.id;
+  const commitSha: string | undefined = payload?.workflow_run?.head_sha;
+
+  if (!owner || !repo || !installationId || !commitSha) {
+    const log = createChildLogger({ owner, repo, commitSha });
+    log.error(
+      { payloadKeys: Object.keys(payload ?? {}) },
+      "Malformed webhook payload: missing required fields"
+    );
+    await updateWebhookStatus(webhookEventId, "error", "Malformed payload");
+    return;
+  }
 
   const log = createChildLogger({ owner, repo, commitSha });
   const startTime = Date.now();
@@ -70,6 +80,7 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
     await saveAnalysis({
       owner,
       repo,
+      installationId,
       commitSha,
       status: "failed",
       errors: [{ reason: `permission_denied: ${reason}` }],
@@ -127,6 +138,7 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
     await saveAnalysis({
       owner,
       repo,
+      installationId,
       commitSha,
       tag: version,
       spec,
@@ -151,6 +163,7 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
     await saveAnalysis({
       owner,
       repo,
+      installationId,
       commitSha,
       status: "failed",
       errors: [{ reason: err instanceof Error ? err.message : String(err) }],
@@ -228,6 +241,7 @@ async function resolveVersion(
 interface SaveAnalysisParams {
   owner: string;
   repo: string;
+  installationId?: number;
   commitSha: string;
   tag?: string;
   spec?: string;
@@ -242,16 +256,40 @@ interface SaveAnalysisParams {
 async function saveAnalysis(params: SaveAnalysisParams): Promise<void> {
   try {
     // Look up repo ID from the repos table
-    const [repoRow] = await db
+    let [repoRow] = await db
       .select({ id: repos.id })
       .from(repos)
       .where(eq(repos.repoFullName, `${params.owner}/${params.repo}`))
       .limit(1);
 
     if (!repoRow) {
-      // If we don't have the repo registered yet, we can't save the analysis
-      // This is a soft failure — the PR was still created
-      return;
+      // Repo not registered yet — try to create it if we know the installation
+      if (params.installationId) {
+        const [instRow] = await db
+          .select({ id: installations.id })
+          .from(installations)
+          .where(eq(installations.githubInstallationId, params.installationId))
+          .limit(1);
+
+        if (instRow) {
+          const [newRepo] = await db
+            .insert(repos)
+            .values({
+              installationId: instRow.id,
+              repoName: params.repo,
+              repoFullName: `${params.owner}/${params.repo}`,
+              isActive: "true",
+            })
+            .returning({ id: repos.id });
+
+          repoRow = newRepo;
+        }
+      }
+
+      if (!repoRow) {
+        // Truly no installation or repo — soft failure, PR was still created
+        return;
+      }
     }
 
     await db.insert(analyses).values({


### PR DESCRIPTION
## Summary
- **Token caching upsert (#5):** When `getValidToken` UPDATE finds zero rows, upsert the installation row instead of just logging a warning
- **Repo row fallback (#11):** When `saveAnalysis` can't find a repo row, create one on-the-fly if the installation exists
- **Payload validation (#9):** Early return with error logging if webhook payload is missing required fields (prevents cascading TypeError in catch block)

**Note:** This PR targets `fix/webhook-installation-handlers` (not `prod`) because it builds on the installation handler changes.

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx jest` — all 135 tests pass
- [x] Verify upsert creates installation row when missing
- [x] Verify malformed payload returns early without crash

Closes #5, Closes #11, Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)