### PR TITLE
fix: parse timeout enforcement, resolveVersion dedup, rate limiter leak

### DIFF
--- a/src/github/prService.ts
+++ b/src/github/prService.ts
@@ -19,6 +19,7 @@ export interface CreatePRParams {
   spec: string;
   parseResult: ParseResult;
   commitSha: string;
+  version: string;
   docsOutput?: string;
 }
 
@@ -122,34 +123,6 @@ function buildPRBody(
 }
 
 /**
- * Determine the version label from tags or fall back to a short SHA.
- */
-async function resolveVersion(
-  octokit: InstanceType<typeof Octokit>,
-  owner: string,
-  repo: string,
-  commitSha: string
-): Promise<string> {
-  try {
-    const { data: tags } = await octokit.rest.repos.listTags({
-      owner,
-      repo,
-      per_page: 100,
-    });
-
-    const matchingTag = tags.find((t) => t.commit.sha === commitSha);
-    if (matchingTag) {
-      // Strip leading "v" (e.g. "v1.2.3" -> "1.2.3")
-      return matchingTag.name.replace(/^v/, "");
-    }
-  } catch (err) {
-    log.warn({ owner, repo, err }, "Failed to fetch tags for version resolution");
-  }
-
-  return commitSha.substring(0, 7);
-}
-
-/**
  * Create a pull request containing the generated OpenAPI spec.
  *
  * The full workflow:
@@ -160,9 +133,9 @@ async function resolveVersion(
  * 5. Open a pull request back to the default branch
  */
 export async function createPR(params: CreatePRParams): Promise<CreatePRResult> {
-  const { owner, repo, installationId, spec, parseResult, commitSha, docsOutput } = params;
+  const { owner, repo, installationId, spec, parseResult, commitSha, version, docsOutput } = params;
 
-  log.info({ owner, repo, commitSha }, "Starting PR creation");
+  log.info({ owner, repo, commitSha, version }, "Starting PR creation");
 
   // 1. Authenticate
   const token = await getValidToken(installationId);
@@ -171,11 +144,7 @@ export async function createPR(params: CreatePRParams): Promise<CreatePRResult> 
     userAgent: "AutoDocAPI/1.0",
   });
 
-  // 2. Resolve version
-  const version = await resolveVersion(octokit, owner, repo, commitSha);
-  log.info({ version }, "Resolved version for PR");
-
-  // 3. Get default branch and its latest commit SHA
+  // 2. Get default branch and its latest commit SHA
   const { data: repoData } = await octokit.rest.repos.get({ owner, repo });
   const defaultBranch = repoData.default_branch;
 

--- a/src/parser/dotnetBridge.ts
+++ b/src/parser/dotnetBridge.ts
@@ -6,7 +6,7 @@ import { ParseResult, RouteInfo, ParamInfo, RequestBodyInfo, ResponseInfo, Prope
 
 const execFileAsync = promisify(execFile);
 
-const DOTNET_TIMEOUT_MS = 120_000;
+const DOTNET_TIMEOUT_MS = config.timeouts?.parseMs ?? 60_000;
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024; // 10 MB
 
 interface DotnetRouteInfo {

--- a/src/parser/expressParser.ts
+++ b/src/parser/expressParser.ts
@@ -498,6 +498,12 @@ export function parseExpressSource(
 // ---------------------------------------------------------------------------
 // Core file-level parser
 // ---------------------------------------------------------------------------
+// TODO(#14): Cross-file router tracking. Currently each file is parsed
+// independently. When a file does `const userRouter = require('./routes/users')`
+// and then `app.use('/api/users', userRouter)`, the prefix is detected but
+// routes defined in the external file are not linked. Full implementation
+// requires: 1) build a map of module exports across all files, 2) resolve
+// require()/import references, 3) compose the full route tree with prefixes.
 
 function parseFile(
   code: string,

--- a/src/pipeline/processAnalysis.ts
+++ b/src/pipeline/processAnalysis.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 
 import { QueueItem } from "../queue/analysisQueue";
 import { createChildLogger } from "../utils/logger";
+import { config } from "../config";
 import { getValidToken } from "../github/appAuth";
 import { checkRepoPermissions, createPR } from "../github/prService";
 import { cloneRepo, removeSensitiveFiles, cleanup } from "../github/repoManager";
@@ -12,6 +13,19 @@ import { generateOpenApiSpec } from "../generator/openApiGenerator";
 import { db } from "../db/connection";
 import { analyses, installations, repos, webhookEvents } from "../db/schema";
 import type { ParseResult } from "../parser/types";
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms
+    );
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() =>
+    clearTimeout(timeoutId)
+  );
+}
 
 async function updateWebhookStatus(
   webhookEventId: number | undefined,
@@ -102,8 +116,12 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
     const framework = await detectFramework(repoPath, autodocConfig);
     log.info({ framework }, "Framework detected");
 
-    // Parse based on framework
-    const parseResult = await parseByFramework(framework, repoPath);
+    // Parse based on framework (with timeout)
+    const parseResult = await withTimeout(
+      parseByFramework(framework, repoPath),
+      config.timeouts.parseMs,
+      "parseByFramework"
+    );
     log.info(
       { routeCount: parseResult.routes.length, errorCount: parseResult.errors.length },
       "Parsing complete"
@@ -128,6 +146,7 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
       spec,
       parseResult,
       commitSha,
+      version,
       docsOutput,
     });
 

--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -21,6 +21,12 @@ export function checkRateLimit(repoFullName: string): boolean {
   // Sliding window: remove timestamps older than 1 hour
   record.timestamps = record.timestamps.filter((ts) => now - ts < windowMs);
 
+  // Evict empty entries to prevent memory leak over time
+  if (record.timestamps.length === 0) {
+    store.delete(repoFullName);
+    return true;
+  }
+
   if (record.timestamps.length >= maxRequests) {
     return false;
   }

--- a/test/parser/dotnetBridge.test.ts
+++ b/test/parser/dotnetBridge.test.ts
@@ -410,7 +410,7 @@ describe("parseDotnet", () => {
         "/my/repo/path",
       ]);
       expect(callArgs[2]).toMatchObject({
-        timeout: 120000,
+        timeout: 60000, // config.timeouts.parseMs default
         maxBuffer: 10 * 1024 * 1024,
       });
     });


### PR DESCRIPTION
## Summary
- **Parse timeout (#12):** Add `withTimeout()` wrapper around `parseByFramework()` using `config.timeouts.parseMs`. Replace hardcoded 120s in dotnetBridge with config value.
- **resolveVersion dedup (#6):** Remove duplicate `resolveVersion()` from `prService.ts`, add `version` to `CreatePRParams`, pass pre-resolved version from `processAnalysis`.
- **Rate limiter leak (#15):** Evict Map entries when all timestamps expire (prevents unbounded growth).
- **Express cross-file docs (#14):** Add TODO comment documenting the limitation and future approach.

**Note:** Targets `fix/token-cache-and-db-resilience` branch (builds on its changes).

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx jest` — all 135 tests pass (dotnetBridge test updated for new timeout value)

Closes #12, Closes #6, Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)