### PR TITLE
fix: parser bugs — Next.js control flow, config, unused import

### DIFF
--- a/src/config/autodocConfig.ts
+++ b/src/config/autodocConfig.ts
@@ -4,7 +4,7 @@ import yaml from "js-yaml";
 import { logger } from "../utils/logger";
 
 export interface AutoDocConfig {
-  framework?: "express" | "nestjs" | "aspnet";
+  framework?: "express" | "nestjs" | "aspnet" | "nextjs";
   docsOutput?: string;
 }
 
@@ -24,7 +24,7 @@ export function loadAutodocConfig(repoPath: string): AutoDocConfig | null {
 
     if (
       typeof parsed.framework === "string" &&
-      ["express", "nestjs", "aspnet"].includes(parsed.framework)
+      ["express", "nestjs", "aspnet", "nextjs"].includes(parsed.framework)
     ) {
       config.framework = parsed.framework as AutoDocConfig["framework"];
     }

--- a/src/detector/frameworkDetector.ts
+++ b/src/detector/frameworkDetector.ts
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import { glob } from "fs/promises";
 import { logger } from "../utils/logger";
 
 export enum Framework {

--- a/src/parser/nextParser.ts
+++ b/src/parser/nextParser.ts
@@ -343,7 +343,7 @@ function parseAppRouterFile(
         for (const declarator of decl.declarations) {
           if (declarator.id?.type !== "Identifier") continue;
           const method = declarator.id.name.toUpperCase();
-          if (!HTTP_METHODS.has(method)) return;
+          if (!HTTP_METHODS.has(method)) continue;
 
           const init = declarator.init;
           if (!init) continue;


### PR DESCRIPTION
## Summary
- **Next.js parser (#2):** Change `return` to `continue` in `parseAppRouterFile()` VariableDeclaration handler — fixes silent route dropping after non-HTTP exports
- **Config (#7):** Add `"nextjs"` to valid framework values in `.autodoc.yml` config
- **Cleanup (#8):** Remove unused `glob` import from `frameworkDetector.ts`

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx jest` — all tests pass

Closes #2, Closes #7, Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)