### PR TITLE
fix: security hardening — path traversal and JWT window

### DIFF
--- a/src/config/autodocConfig.ts
+++ b/src/config/autodocConfig.ts
@@ -30,7 +30,12 @@ export function loadAutodocConfig(repoPath: string): AutoDocConfig | null {
     }
 
     if (typeof parsed.docs_output === "string") {
-      config.docsOutput = parsed.docs_output;
+      const normalized = path.posix.normalize(parsed.docs_output);
+      if (normalized.startsWith("..") || path.isAbsolute(normalized)) {
+        logger.warn({ docsOutput: parsed.docs_output }, "Rejected unsafe docs_output path");
+      } else {
+        config.docsOutput = normalized;
+      }
     }
 
     logger.info({ config }, "Loaded .autodoc.yml");

--- a/src/github/appAuth.ts
+++ b/src/github/appAuth.ts
@@ -30,7 +30,7 @@ function createAppJwt(): string {
   const now = Math.floor(Date.now() / 1000);
   const payload = {
     iat: now - 60, // issued 60s in the past to account for clock drift
-    exp: now + 10 * 60, // 10 minute maximum
+    exp: now + 9 * 60, // 9 min from now; total window = 10 min with 60s IAT backdate
     iss: config.github.appId,
   };
   return jwt.sign(payload, getPrivateKey(), { algorithm: "RS256" });

--- a/src/github/prService.ts
+++ b/src/github/prService.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { Octokit } from "@octokit/rest";
 
 import { getValidToken } from "./appAuth";
@@ -198,6 +199,10 @@ export async function createPR(params: CreatePRParams): Promise<CreatePRResult> 
 
   // 5. Create or update the spec file
   const filePath = docsOutput || "docs/openapi.yaml";
+  const normalizedPath = path.posix.normalize(filePath);
+  if (normalizedPath.startsWith("..") || path.isAbsolute(normalizedPath)) {
+    throw new Error(`Unsafe file path rejected: ${filePath}`);
+  }
   const contentBase64 = Buffer.from(spec, "utf8").toString("base64");
   const commitMessage = "docs: update API documentation (AutoDocAPI)";
 
@@ -207,7 +212,7 @@ export async function createPR(params: CreatePRParams): Promise<CreatePRResult> 
     const { data: existingFile } = await octokit.rest.repos.getContent({
       owner,
       repo,
-      path: filePath,
+      path: normalizedPath,
       ref: branchName,
     });
     // getContent returns either a file object or an array (directory listing).
@@ -225,13 +230,13 @@ export async function createPR(params: CreatePRParams): Promise<CreatePRResult> 
   await octokit.rest.repos.createOrUpdateFileContents({
     owner,
     repo,
-    path: filePath,
+    path: normalizedPath,
     message: commitMessage,
     content: contentBase64,
     branch: branchName,
     ...(existingFileSha ? { sha: existingFileSha } : {}),
   });
-  log.info({ filePath, branchName }, "Committed spec file");
+  log.info({ filePath: normalizedPath, branchName }, "Committed spec file");
 
   // 6. Open the pull request
   const prTitle = `docs: API documentation update \u2014 ${version}`;


### PR DESCRIPTION
## Summary
- **Path traversal (#3):** Sanitize `docs_output` from `.autodoc.yml` — reject `../` and absolute paths. Add secondary defense in `prService.ts`.
- **JWT window (#4):** Reduce `exp` to 9 minutes from now (total window = 10 min with 60s IAT backdate), matching GitHub's hard limit.

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx jest` — all 135 tests pass

Closes #3, Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)