### PR TITLE
fix: PR timeout enforcement and ASP.NET Minimal API detection expansion

### DIFF
--- a/src/detector/frameworkDetector.ts
+++ b/src/detector/frameworkDetector.ts
@@ -140,7 +140,13 @@ async function checkForMinimalApi(repoPath: string): Promise<boolean> {
       }
     }
   }
-  return false;
+  // Fallback: search all .cs files for Minimal API patterns
+  return (
+    (await searchInCsFiles(repoPath, "MapGet")) ||
+    (await searchInCsFiles(repoPath, "MapPost")) ||
+    (await searchInCsFiles(repoPath, "MapPut")) ||
+    (await searchInCsFiles(repoPath, "MapDelete"))
+  );
 }
 
 async function searchInCsFiles(

--- a/src/pipeline/processAnalysis.ts
+++ b/src/pipeline/processAnalysis.ts
@@ -137,18 +137,22 @@ export async function processAnalysis(item: QueueItem): Promise<void> {
       version,
     });
 
-    // Create PR
+    // Create PR (with timeout)
     const docsOutput = autodocConfig?.docsOutput;
-    const prResult = await createPR({
-      owner,
-      repo,
-      installationId,
-      spec,
-      parseResult,
-      commitSha,
-      version,
-      docsOutput,
-    });
+    const prResult = await withTimeout(
+      createPR({
+        owner,
+        repo,
+        installationId,
+        spec,
+        parseResult,
+        commitSha,
+        version,
+        docsOutput,
+      }),
+      config.timeouts.prMs,
+      "createPR"
+    );
 
     log.info({ prNumber: prResult.prNumber, prUrl: prResult.prUrl }, "PR created");
 


### PR DESCRIPTION
## Summary
- **PR timeout (#24):** Wrap `createPR()` with `withTimeout(config.timeouts.prMs)` (default 15s) to prevent indefinite hangs on slow GitHub API
- **ASP.NET detection (#26):** `checkForMinimalApi()` now falls back to `searchInCsFiles()` for MapGet/MapPost/MapPut/MapDelete across all .cs files, not just root Program.cs/Startup.cs

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx jest` — all 135 tests pass

Closes #24, Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)