### PR TITLE
test: infrastructure test coverage and rate limiter eviction fix

### DIFF
--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -14,8 +14,9 @@ export function checkRateLimit(repoFullName: string): boolean {
 
   let record = store.get(repoFullName);
   if (!record) {
-    record = { timestamps: [] };
+    record = { timestamps: [now] };
     store.set(repoFullName, record);
+    return true;
   }
 
   // Sliding window: remove timestamps older than 1 hour
@@ -24,6 +25,8 @@ export function checkRateLimit(repoFullName: string): boolean {
   // Evict empty entries to prevent memory leak over time
   if (record.timestamps.length === 0) {
     store.delete(repoFullName);
+    record = { timestamps: [now] };
+    store.set(repoFullName, record);
     return true;
   }
 

--- a/test/config/autodocConfig.test.ts
+++ b/test/config/autodocConfig.test.ts
@@ -1,0 +1,127 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { loadAutodocConfig } from "../../src/config/autodocConfig";
+
+jest.mock("../../src/utils/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    child: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+    })),
+  },
+}));
+
+function createTempRepo(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "autodoc-config-"));
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content);
+  }
+  return dir;
+}
+
+describe("autodocConfig", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should return null when no .autodoc.yml exists", () => {
+    tmpDir = createTempRepo({});
+    expect(loadAutodocConfig(tmpDir)).toBeNull();
+  });
+
+  it("should parse valid framework config", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "framework: express\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.framework).toBe("express");
+  });
+
+  it("should accept nextjs as valid framework", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "framework: nextjs\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.framework).toBe("nextjs");
+  });
+
+  it("should accept nestjs as valid framework", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "framework: nestjs\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.framework).toBe("nestjs");
+  });
+
+  it("should accept aspnet as valid framework", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "framework: aspnet\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.framework).toBe("aspnet");
+  });
+
+  it("should ignore unknown framework values", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "framework: django\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.framework).toBeUndefined();
+  });
+
+  it("should parse docs_output", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "docs_output: api/spec.yaml\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.docsOutput).toBe("api/spec.yaml");
+  });
+
+  it("should reject path traversal in docs_output", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "docs_output: ../../.github/workflows/evil.yml\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.docsOutput).toBeUndefined();
+  });
+
+  it("should reject absolute path in docs_output", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "docs_output: /etc/passwd\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.docsOutput).toBeUndefined();
+  });
+
+  it("should reject parent directory traversal in docs_output", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "docs_output: docs/../../../etc/passwd\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.docsOutput).toBeUndefined();
+  });
+
+  it("should return null for invalid YAML", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": ": invalid: yaml: [[[",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config).toBeNull();
+  });
+
+  it("should parse both framework and docs_output together", () => {
+    tmpDir = createTempRepo({
+      ".autodoc.yml": "framework: express\ndocs_output: docs/api.yaml\n",
+    });
+    const config = loadAutodocConfig(tmpDir);
+    expect(config?.framework).toBe("express");
+    expect(config?.docsOutput).toBe("docs/api.yaml");
+  });
+});

--- a/test/queue/analysisQueue.test.ts
+++ b/test/queue/analysisQueue.test.ts
@@ -1,0 +1,59 @@
+jest.mock("../../src/config", () => ({
+  config: {
+    limits: { maxConcurrentAnalyses: 2 },
+  },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    })),
+  },
+}));
+
+import { analysisQueue } from "../../src/queue/analysisQueue";
+
+describe("analysisQueue", () => {
+  it("should report queue length", () => {
+    expect(typeof analysisQueue.getQueueLength()).toBe("number");
+  });
+
+  it("should report active count", () => {
+    expect(typeof analysisQueue.getActiveCount()).toBe("number");
+  });
+
+  it("should report repo active status", () => {
+    expect(analysisQueue.isRepoActive("nonexistent/repo")).toBe(false);
+  });
+
+  it("should accept a processor function", () => {
+    expect(() => {
+      analysisQueue.setProcessor(async () => {});
+    }).not.toThrow();
+  });
+
+  it("should enqueue items and process them", (done) => {
+    const processed: string[] = [];
+
+    analysisQueue.setProcessor(async (item) => {
+      processed.push(item.repoFullName);
+      if (processed.length === 1) {
+        expect(processed).toContain("test/enqueue-repo");
+        done();
+      }
+    });
+
+    analysisQueue.enqueue({
+      id: `test-enqueue-${Date.now()}`,
+      repoFullName: "test/enqueue-repo",
+      payload: {},
+      addedAt: Date.now(),
+    });
+  });
+});

--- a/test/utils/rateLimiter.test.ts
+++ b/test/utils/rateLimiter.test.ts
@@ -1,0 +1,81 @@
+jest.mock("../../src/config", () => ({
+  config: {
+    limits: { rateLimitPerHour: 3 },
+  },
+}));
+
+import { checkRateLimit, resetRateLimiter } from "../../src/utils/rateLimiter";
+
+describe("rateLimiter", () => {
+  beforeEach(() => {
+    resetRateLimiter();
+  });
+
+  it("should allow requests under the limit", () => {
+    expect(checkRateLimit("owner/repo")).toBe(true);
+    expect(checkRateLimit("owner/repo")).toBe(true);
+    expect(checkRateLimit("owner/repo")).toBe(true);
+  });
+
+  it("should reject requests over the limit", () => {
+    expect(checkRateLimit("owner/repo")).toBe(true);
+    expect(checkRateLimit("owner/repo")).toBe(true);
+    expect(checkRateLimit("owner/repo")).toBe(true);
+    expect(checkRateLimit("owner/repo")).toBe(false);
+  });
+
+  it("should track repos independently", () => {
+    expect(checkRateLimit("owner/repo-a")).toBe(true);
+    expect(checkRateLimit("owner/repo-a")).toBe(true);
+    expect(checkRateLimit("owner/repo-a")).toBe(true);
+    expect(checkRateLimit("owner/repo-a")).toBe(false);
+
+    // Different repo should still be allowed
+    expect(checkRateLimit("owner/repo-b")).toBe(true);
+  });
+
+  it("should allow requests after window expires", () => {
+    const realDateNow = Date.now;
+
+    let now = 1000000;
+    Date.now = jest.fn(() => now);
+
+    expect(checkRateLimit("owner/repo")).toBe(true);
+    expect(checkRateLimit("owner/repo")).toBe(true);
+    expect(checkRateLimit("owner/repo")).toBe(true);
+    expect(checkRateLimit("owner/repo")).toBe(false);
+
+    // Advance past 1 hour window
+    now += 60 * 60 * 1000 + 1;
+    expect(checkRateLimit("owner/repo")).toBe(true);
+
+    Date.now = realDateNow;
+  });
+
+  it("should evict empty entries after window expires", () => {
+    const realDateNow = Date.now;
+
+    let now = 1000000;
+    Date.now = jest.fn(() => now);
+
+    checkRateLimit("owner/repo");
+
+    // Advance past window
+    now += 60 * 60 * 1000 + 1;
+
+    // Next call should evict and return true
+    expect(checkRateLimit("owner/repo")).toBe(true);
+
+    Date.now = realDateNow;
+  });
+
+  it("should reset all state", () => {
+    checkRateLimit("owner/repo");
+    checkRateLimit("owner/repo");
+    checkRateLimit("owner/repo");
+    expect(checkRateLimit("owner/repo")).toBe(false);
+
+    resetRateLimiter();
+    expect(checkRateLimit("owner/repo")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- **rateLimiter tests** (6 tests): sliding window, limit enforcement, eviction after window expiry, reset, independent repo tracking
- **autodocConfig tests** (12 tests): YAML loading, all 4 framework values, unknown framework rejection, path traversal rejection (3 variants), invalid YAML, combined config
- **analysisQueue tests** (5 tests): queue length, active count, repo status, processor assignment, enqueue+process
- **Bug fix:** Rate limiter eviction was broken — new records with `timestamps: []` were immediately evicted before recording the first timestamp, causing the rate limiter to never count

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx jest` — 158/158 tests pass (23 new)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)