### PR TITLE
feat: NestJS @HttpCode and @ApiResponse decorator support

### DIFF
--- a/src/parser/nestParser.ts
+++ b/src/parser/nestParser.ts
@@ -226,7 +226,114 @@ function extractRequestBody(method: MethodDeclaration): RequestBodyInfo | null {
   return null;
 }
 
+function extractHttpCode(method: MethodDeclaration): number {
+  const decorator = method.getDecorator("HttpCode");
+  if (decorator) {
+    const args = decorator.getArguments();
+    if (args.length > 0) {
+      const code = parseInt(args[0].getText(), 10);
+      if (!isNaN(code)) return code;
+    }
+  }
+  return 200;
+}
+
+function extractDecoratorTypeArg(
+  decorator: Decorator,
+  visited: Set<string>
+): { typeName: string; properties: PropertyInfo[] } | null {
+  const args = decorator.getArguments();
+  if (args.length === 0) return null;
+
+  const argText = args[0].getText();
+  const typeMatch = argText.match(/type\s*:\s*(\w+)/);
+  if (!typeMatch) return null;
+
+  const typeName = typeMatch[1];
+  const sourceFile = decorator.getSourceFile();
+
+  // Try local declarations first
+  const localDecl = sourceFile.getTypeAlias(typeName) || sourceFile.getInterface(typeName) || sourceFile.getClass(typeName);
+  if (localDecl) {
+    const type = localDecl.getType();
+    const properties = resolveTypeProperties(type, new Set(visited));
+    return { typeName, properties };
+  }
+
+  // Try resolving through imports across the project
+  const project = sourceFile.getProject();
+  for (const sf of project.getSourceFiles()) {
+    const decl = sf.getTypeAlias(typeName) || sf.getInterface(typeName) || sf.getClass(typeName);
+    if (decl) {
+      const type = decl.getType();
+      const properties = resolveTypeProperties(type, new Set(visited));
+      return { typeName, properties };
+    }
+  }
+
+  return { typeName, properties: [] };
+}
+
+function extractApiResponses(method: MethodDeclaration, visited: Set<string>): ResponseInfo[] | null {
+  const DECORATOR_STATUS_MAP: Record<string, number> = {
+    ApiOkResponse: 200,
+    ApiCreatedResponse: 201,
+    ApiAcceptedResponse: 202,
+    ApiNoContentResponse: 204,
+    ApiBadRequestResponse: 400,
+    ApiUnauthorizedResponse: 401,
+    ApiForbiddenResponse: 403,
+    ApiNotFoundResponse: 404,
+    ApiConflictResponse: 409,
+    ApiInternalServerErrorResponse: 500,
+  };
+
+  const decorators = method.getDecorators();
+  const responses: ResponseInfo[] = [];
+
+  for (const dec of decorators) {
+    const name = dec.getName();
+
+    // Named response decorators (e.g., @ApiOkResponse({ type: UserDto }))
+    if (DECORATOR_STATUS_MAP[name] !== undefined) {
+      const status = DECORATOR_STATUS_MAP[name];
+      const typeInfo = extractDecoratorTypeArg(dec, visited);
+      responses.push({
+        status,
+        type: typeInfo?.typeName ?? null,
+        properties: typeInfo?.properties ?? [],
+      });
+      continue;
+    }
+
+    // Generic @ApiResponse({ status: 200, type: UserDto })
+    if (name === "ApiResponse") {
+      const args = dec.getArguments();
+      if (args.length > 0) {
+        const argText = args[0].getText();
+        const statusMatch = argText.match(/status\s*:\s*(\d+)/);
+        const status = statusMatch ? parseInt(statusMatch[1], 10) : 200;
+        const typeInfo = extractDecoratorTypeArg(dec, visited);
+        responses.push({
+          status,
+          type: typeInfo?.typeName ?? null,
+          properties: typeInfo?.properties ?? [],
+        });
+      }
+    }
+  }
+
+  return responses.length > 0 ? responses : null;
+}
+
 function extractResponses(method: MethodDeclaration): ResponseInfo[] {
+  // 1. Check for Swagger/OpenAPI decorators first
+  const apiResponses = extractApiResponses(method, new Set<string>());
+  if (apiResponses) return apiResponses;
+
+  // 2. Fall back to return type analysis with @HttpCode support
+  const statusCode = extractHttpCode(method);
+
   const returnType = method.getReturnType();
   let resolvedType = returnType;
   let typeName = simplifyTypeName(returnType.getText());
@@ -241,14 +348,14 @@ function extractResponses(method: MethodDeclaration): ResponseInfo[] {
   }
 
   if (typeName === "void" || typeName === "undefined") {
-    return [{ status: 200, type: null, properties: [] }];
+    return [{ status: statusCode, type: null, properties: [] }];
   }
 
   const properties = resolveTypeProperties(resolvedType, new Set<string>());
 
   return [
     {
-      status: 200,
+      status: statusCode,
       type: typeName,
       properties,
     },

--- a/test/parser/nestParser.test.ts
+++ b/test/parser/nestParser.test.ts
@@ -687,6 +687,151 @@ describe("NestJS Parser", () => {
     expect(methods).toEqual(["DELETE", "GET", "PATCH", "POST", "PUT"]);
   });
 
+  test("@HttpCode decorator overrides default status code", () => {
+    tmpDir = createTempProject({
+      "src/users.controller.ts": `
+        function Controller(prefix?: string): ClassDecorator { return () => {}; }
+        function Post(path?: string): MethodDecorator { return () => {}; }
+        function HttpCode(code: number): MethodDecorator { return () => {}; }
+        function Body(): ParameterDecorator { return () => {}; }
+
+        @Controller('users')
+        export class UsersController {
+          @Post()
+          @HttpCode(201)
+          create(@Body() data: any): void {}
+        }
+      `,
+    });
+
+    const result = parseNestRoutes(tmpDir);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.routes).toHaveLength(1);
+
+    const route = result.routes[0];
+    expect(route.method).toBe("POST");
+    expect(route.responses).toHaveLength(1);
+    expect(route.responses[0].status).toBe(201);
+  });
+
+  test("@ApiResponse decorator with status and type", () => {
+    tmpDir = createTempProject({
+      "src/dto/create-user.dto.ts": `
+        export class CreateUserDto {
+          name: string;
+          email: string;
+        }
+      `,
+      "src/users.controller.ts": `
+        import { CreateUserDto } from './dto/create-user.dto';
+
+        function Controller(prefix?: string): ClassDecorator { return () => {}; }
+        function Post(path?: string): MethodDecorator { return () => {}; }
+        function ApiResponse(options: any): MethodDecorator { return () => {}; }
+
+        @Controller('users')
+        export class UsersController {
+          @Post()
+          @ApiResponse({ status: 201, type: CreateUserDto })
+          create(): void {}
+        }
+      `,
+    });
+
+    const result = parseNestRoutes(tmpDir);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.routes).toHaveLength(1);
+
+    const route = result.routes[0];
+    expect(route.responses).toHaveLength(1);
+    expect(route.responses[0].status).toBe(201);
+    expect(route.responses[0].type).toBe("CreateUserDto");
+    expect(route.responses[0].properties.length).toBeGreaterThanOrEqual(2);
+
+    const nameProp = route.responses[0].properties.find((p) => p.name === "name");
+    expect(nameProp).toBeDefined();
+    expect(nameProp!.type).toBe("string");
+  });
+
+  test("@ApiOkResponse decorator with type", () => {
+    tmpDir = createTempProject({
+      "src/dto/user.dto.ts": `
+        export class UserDto {
+          id: number;
+          name: string;
+          email: string;
+        }
+      `,
+      "src/users.controller.ts": `
+        import { UserDto } from './dto/user.dto';
+
+        function Controller(prefix?: string): ClassDecorator { return () => {}; }
+        function Get(path?: string): MethodDecorator { return () => {}; }
+        function ApiOkResponse(options: any): MethodDecorator { return () => {}; }
+
+        @Controller('users')
+        export class UsersController {
+          @Get()
+          @ApiOkResponse({ type: UserDto })
+          findAll(): void {}
+        }
+      `,
+    });
+
+    const result = parseNestRoutes(tmpDir);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.routes).toHaveLength(1);
+
+    const route = result.routes[0];
+    expect(route.responses).toHaveLength(1);
+    expect(route.responses[0].status).toBe(200);
+    expect(route.responses[0].type).toBe("UserDto");
+    expect(route.responses[0].properties.length).toBeGreaterThanOrEqual(3);
+
+    const idProp = route.responses[0].properties.find((p) => p.name === "id");
+    expect(idProp).toBeDefined();
+    expect(idProp!.type).toBe("number");
+  });
+
+  test("No response decorators falls back to return type with status 200", () => {
+    tmpDir = createTempProject({
+      "src/dto/item.dto.ts": `
+        export class ItemDto {
+          id: number;
+          title: string;
+        }
+      `,
+      "src/items.controller.ts": `
+        import { ItemDto } from './dto/item.dto';
+
+        function Controller(prefix?: string): ClassDecorator { return () => {}; }
+        function Get(path?: string): MethodDecorator { return () => {}; }
+
+        @Controller('items')
+        export class ItemsController {
+          @Get()
+          async findAll(): Promise<ItemDto> {
+            return null as any;
+          }
+        }
+      `,
+    });
+
+    const result = parseNestRoutes(tmpDir);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.routes).toHaveLength(1);
+
+    const route = result.routes[0];
+    expect(route.responses).toHaveLength(1);
+    expect(route.responses[0].status).toBe(200);
+    expect(route.responses[0].type).toBe("ItemDto");
+    expect(route.responses[0].properties.length).toBeGreaterThanOrEqual(2);
+  });
+
   test("No controllers found returns empty routes", () => {
     tmpDir = createTempProject({
       "src/service.ts": `


### PR DESCRIPTION
## Summary
- **@HttpCode(n):** Override default 200 status code on controller methods
- **@ApiResponse({ status, type }):** Extract status and resolve type properties from Swagger decorators
- **Named decorators:** Support `@ApiOkResponse`, `@ApiCreatedResponse`, `@ApiBadRequestResponse`, `@ApiNotFoundResponse`, etc.
- **Type resolution:** Decorator type arguments resolved via ts-morph across all project source files
- Existing behavior unchanged for methods without these decorators

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx jest` ��� 139/139 tests pass (4 new NestJS tests)
- [x] `@HttpCode(201)` → status 201
- [x] `@ApiResponse({ status: 201, type: CreateUserDto })` → status 201 with properties
- [x] `@ApiOkResponse({ type: UserDto })` �� status 200 with properties
- [x] No decorators → existing return type + status 200

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)