### PR TITLE
test: full pipeline test coverage — 207 total tests

### DIFF
--- a/test/api/webhookHandler.test.ts
+++ b/test/api/webhookHandler.test.ts
@@ -1,0 +1,291 @@
+import crypto from "crypto";
+
+const WEBHOOK_SECRET = "test-webhook-secret";
+
+jest.mock("../../src/config", () => ({
+  config: {
+    github: {
+      webhookSecret: "test-webhook-secret",
+      appId: "test",
+      privateKeyPath: "/test.pem",
+    },
+    limits: { rateLimitPerHour: 10 },
+  },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    })),
+  },
+}));
+
+const mockEnqueue = jest.fn();
+jest.mock("../../src/queue/analysisQueue", () => ({
+  analysisQueue: { enqueue: mockEnqueue },
+  QueueItem: {},
+}));
+
+const mockCheckRateLimit = jest.fn().mockReturnValue(true);
+jest.mock("../../src/utils/rateLimiter", () => ({
+  checkRateLimit: mockCheckRateLimit,
+}));
+
+// DB mock
+const mockDbReturning = jest.fn().mockResolvedValue([{ id: 1 }]);
+const mockDbOnConflict = jest.fn(() => ({ returning: mockDbReturning }));
+const mockDbValues = jest.fn(() => ({
+  returning: mockDbReturning,
+  onConflictDoNothing: mockDbOnConflict,
+}));
+const mockDbInsert = jest.fn(() => ({ values: mockDbValues }));
+const mockDbSelectLimit = jest.fn().mockResolvedValue([{ id: 1 }]);
+const mockDbSelectWhere = jest.fn(() => ({ limit: mockDbSelectLimit }));
+const mockDbSelectFrom = jest.fn(() => ({ where: mockDbSelectWhere }));
+const mockDbSelect = jest.fn(() => ({ from: mockDbSelectFrom }));
+const mockDbDeleteWhere = jest.fn().mockResolvedValue({});
+const mockDbDelete = jest.fn(() => ({ where: mockDbDeleteWhere }));
+
+jest.mock("../../src/db/connection", () => ({
+  db: {
+    insert: mockDbInsert,
+    select: mockDbSelect,
+    delete: mockDbDelete,
+  },
+}));
+
+jest.mock("../../src/db/schema", () => ({
+  webhookEvents: { id: "id" },
+  installations: { id: "id", githubInstallationId: "github_installation_id" },
+  repos: { id: "id", installationId: "installation_id", repoFullName: "repo_full_name" },
+}));
+
+import { webhookHandler } from "../../src/api/webhookHandler";
+
+function makeSignature(body: string): string {
+  return (
+    "sha256=" +
+    crypto.createHmac("sha256", WEBHOOK_SECRET).update(body).digest("hex")
+  );
+}
+
+function makeReq(overrides: any = {}) {
+  const body = overrides.body ?? {
+    action: "completed",
+    workflow_run: { conclusion: "success", head_sha: "abc123" },
+    repository: { full_name: "owner/repo", name: "repo", owner: { login: "owner" } },
+    installation: { id: 123, account: { login: "owner" } },
+  };
+  const rawBody = Buffer.from(JSON.stringify(body));
+  return {
+    headers: {
+      "x-hub-signature-256": makeSignature(rawBody.toString()),
+      "x-github-event": overrides.event ?? "workflow_run",
+      ...overrides.headers,
+    },
+    body,
+    rawBody,
+    ...overrides,
+  } as any;
+}
+
+function makeRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("webhookHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue(true);
+    mockDbReturning.mockResolvedValue([{ id: 1 }]);
+    mockDbSelectLimit.mockResolvedValue([{ id: 1 }]);
+  });
+
+  describe("signature verification", () => {
+    it("should reject missing signature", async () => {
+      const req = makeReq({ headers: {} });
+      delete req.headers["x-hub-signature-256"];
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it("should reject invalid signature", async () => {
+      const req = makeReq();
+      req.headers["x-hub-signature-256"] = "sha256=invalid";
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it("should reject missing rawBody", async () => {
+      const req = makeReq();
+      delete req.rawBody;
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it("should accept valid signature", async () => {
+      const req = makeReq();
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(202);
+    });
+  });
+
+  describe("event dispatch", () => {
+    it("should ignore unknown event types", async () => {
+      const req = makeReq({ event: "push" });
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ ignored: true })
+      );
+    });
+
+    it("should handle workflow_run completed success", async () => {
+      const req = makeReq();
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(mockEnqueue).toHaveBeenCalled();
+    });
+
+    it("should ignore workflow_run with non-completed action", async () => {
+      const req = makeReq({
+        body: {
+          action: "requested",
+          workflow_run: { conclusion: "success", head_sha: "abc" },
+          repository: { full_name: "o/r", name: "r", owner: { login: "o" } },
+          installation: { id: 1, account: { login: "o" } },
+        },
+      });
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it("should ignore workflow_run with non-success conclusion", async () => {
+      const req = makeReq({
+        body: {
+          action: "completed",
+          workflow_run: { conclusion: "failure", head_sha: "abc" },
+          repository: { full_name: "o/r", name: "r", owner: { login: "o" } },
+          installation: { id: 1, account: { login: "o" } },
+        },
+      });
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe("rate limiting", () => {
+    it("should reject when rate limit exceeded", async () => {
+      mockCheckRateLimit.mockReturnValue(false);
+      const req = makeReq();
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(429);
+    });
+  });
+
+  describe("installation events", () => {
+    it("should handle installation.created", async () => {
+      const req = makeReq({
+        event: "installation",
+        body: {
+          action: "created",
+          installation: { id: 456, account: { login: "test-owner" } },
+          repositories: [{ name: "repo1", full_name: "test-owner/repo1" }],
+        },
+      });
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockDbInsert).toHaveBeenCalled();
+    });
+
+    it("should handle installation.deleted", async () => {
+      const req = makeReq({
+        event: "installation",
+        body: {
+          action: "deleted",
+          installation: { id: 456, account: { login: "test-owner" } },
+        },
+      });
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockDbDelete).toHaveBeenCalled();
+    });
+
+    it("should reject malformed installation event", async () => {
+      const req = makeReq({
+        event: "installation",
+        body: { action: "created" },
+      });
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe("installation_repositories events", () => {
+    it("should handle repositories added", async () => {
+      const req = makeReq({
+        event: "installation_repositories",
+        body: {
+          action: "added",
+          installation: { id: 456 },
+          repositories_added: [{ name: "new-repo", full_name: "owner/new-repo" }],
+        },
+      });
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("should handle repositories removed", async () => {
+      const req = makeReq({
+        event: "installation_repositories",
+        body: {
+          action: "removed",
+          installation: { id: 456 },
+          repositories_removed: [{ full_name: "owner/old-repo" }],
+        },
+      });
+      const res = makeRes();
+
+      await webhookHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+});

--- a/test/github/appAuth.test.ts
+++ b/test/github/appAuth.test.ts
@@ -1,0 +1,148 @@
+const mockSign = jest.fn().mockReturnValue("mock-jwt-token");
+const mockReadFileSync = jest.fn().mockReturnValue("mock-private-key");
+
+jest.mock("fs", () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+jest.mock("jsonwebtoken", () => ({
+  sign: mockSign,
+}));
+
+jest.mock("../../src/config", () => ({
+  config: {
+    github: {
+      appId: "12345",
+      privateKeyPath: "/test/key.pem",
+      webhookSecret: "test-secret",
+    },
+  },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    })),
+  },
+}));
+
+const mockSelectLimit = jest.fn();
+const mockSelectWhere = jest.fn(() => ({ limit: mockSelectLimit }));
+const mockSelectFrom = jest.fn(() => ({ where: mockSelectWhere }));
+const mockSelect = jest.fn(() => ({ from: mockSelectFrom }));
+
+const mockUpdateWhere = jest.fn();
+const mockUpdateSet = jest.fn(() => ({ where: mockUpdateWhere }));
+const mockUpdate = jest.fn(() => ({ set: mockUpdateSet }));
+
+const mockInsertOnConflict = jest.fn().mockResolvedValue({});
+const mockInsertValues = jest.fn(() => ({ onConflictDoUpdate: mockInsertOnConflict }));
+const mockInsert = jest.fn(() => ({ values: mockInsertValues }));
+
+jest.mock("../../src/db/connection", () => ({
+  db: {
+    select: mockSelect,
+    update: mockUpdate,
+    insert: mockInsert,
+  },
+}));
+
+const mockOctokitRequest = jest.fn();
+
+jest.mock("@octokit/rest", () => ({
+  Octokit: jest.fn().mockImplementation(() => ({
+    request: mockOctokitRequest,
+  })),
+}));
+
+import { createAppOctokit, getValidToken } from "../../src/github/appAuth";
+
+describe("appAuth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReadFileSync.mockReturnValue("mock-private-key");
+    mockSign.mockReturnValue("mock-jwt-token");
+  });
+
+  describe("createAppOctokit", () => {
+    it("should create an Octokit instance with JWT auth", () => {
+      const octokit = createAppOctokit();
+      expect(octokit).toBeDefined();
+      expect(mockSign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          iss: "12345",
+        }),
+        "mock-private-key",
+        { algorithm: "RS256" }
+      );
+    });
+
+    it("should create JWT with iat backdated 60s and exp within 10 min window", () => {
+      createAppOctokit();
+
+      const payload = mockSign.mock.calls[0][0];
+      expect(payload.exp - payload.iat).toBeLessThanOrEqual(600);
+      expect(payload.exp - payload.iat).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getValidToken", () => {
+    it("should reuse cached token when not near expiry", async () => {
+      const futureDate = new Date(Date.now() + 30 * 60 * 1000); // 30 min from now
+      mockSelectLimit.mockResolvedValueOnce([{
+        accessToken: "cached-token",
+        tokenExpiresAt: futureDate,
+      }]);
+
+      const token = await getValidToken(123);
+      expect(token).toBe("cached-token");
+      expect(mockOctokitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should refresh token when near expiry", async () => {
+      const nearExpiry = new Date(Date.now() + 2 * 60 * 1000); // 2 min from now (< 5 min buffer)
+      mockSelectLimit.mockResolvedValueOnce([{
+        accessToken: "old-token",
+        tokenExpiresAt: nearExpiry,
+      }]);
+
+      mockOctokitRequest.mockResolvedValueOnce({
+        data: {
+          token: "new-token",
+          expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        },
+      });
+
+      mockUpdateWhere.mockResolvedValueOnce({ rowCount: 1 });
+
+      const token = await getValidToken(123);
+      expect(token).toBe("new-token");
+      expect(mockOctokitRequest).toHaveBeenCalled();
+    });
+
+    it("should request new token when no cached token exists", async () => {
+      mockSelectLimit.mockResolvedValueOnce([]);
+
+      mockOctokitRequest.mockResolvedValueOnce({
+        data: {
+          token: "fresh-token",
+          expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        },
+      });
+
+      mockUpdateWhere.mockResolvedValueOnce({ rowCount: 0 });
+
+      const token = await getValidToken(456);
+      expect(token).toBe("fresh-token");
+      expect(mockInsert).toHaveBeenCalled(); // upsert fallback
+    });
+  });
+});

--- a/test/github/prService.test.ts
+++ b/test/github/prService.test.ts
@@ -1,0 +1,228 @@
+jest.mock("../../src/config", () => ({
+  config: {
+    github: { appId: "test", privateKeyPath: "/test.pem", webhookSecret: "secret" },
+    timeouts: { cloneMs: 30000, prMs: 15000 },
+  },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    })),
+  },
+}));
+
+jest.mock("../../src/github/appAuth", () => ({
+  getValidToken: jest.fn().mockResolvedValue("mock-token"),
+}));
+
+const mockOctokit = {
+  rest: {
+    repos: {
+      get: jest.fn(),
+      getContent: jest.fn(),
+      createOrUpdateFileContents: jest.fn(),
+    },
+    git: {
+      getRef: jest.fn(),
+      createRef: jest.fn(),
+    },
+    pulls: {
+      create: jest.fn(),
+    },
+  },
+};
+
+jest.mock("@octokit/rest", () => ({
+  Octokit: jest.fn(() => mockOctokit),
+}));
+
+import { checkRepoPermissions, createPR } from "../../src/github/prService";
+import type { ParseResult } from "../../src/parser/types";
+
+const emptyParseResult: ParseResult = { routes: [], errors: [] };
+const sampleParseResult: ParseResult = {
+  routes: [
+    {
+      path: "/api/users",
+      method: "GET",
+      controller: "UsersController",
+      routePrefix: "/api",
+      params: [],
+      requestBody: null,
+      responses: [{ status: 200, type: "User[]", properties: [] }],
+      auth: null,
+      middleware: [],
+      description: null,
+      source: "users.ts",
+    },
+  ],
+  errors: [],
+};
+
+describe("prService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("checkRepoPermissions", () => {
+    it("should return canPush true for repo with push permission", async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            get: jest.fn().mockResolvedValue({
+              data: { permissions: { push: true }, archived: false },
+            }),
+          },
+        },
+      } as any;
+
+      const result = await checkRepoPermissions(octokit, "owner", "repo");
+      expect(result.canPush).toBe(true);
+      expect(result.archived).toBe(false);
+    });
+
+    it("should return archived true for archived repo", async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            get: jest.fn().mockResolvedValue({
+              data: { permissions: { push: true }, archived: true },
+            }),
+          },
+        },
+      } as any;
+
+      const result = await checkRepoPermissions(octokit, "owner", "repo");
+      expect(result.archived).toBe(true);
+    });
+
+    it("should return canPush false when no push permission", async () => {
+      const octokit = {
+        rest: {
+          repos: {
+            get: jest.fn().mockResolvedValue({
+              data: { permissions: { push: false }, archived: false },
+            }),
+          },
+        },
+      } as any;
+
+      const result = await checkRepoPermissions(octokit, "owner", "repo");
+      expect(result.canPush).toBe(false);
+    });
+  });
+
+  describe("createPR", () => {
+    beforeEach(() => {
+      mockOctokit.rest.repos.get.mockResolvedValue({
+        data: { default_branch: "main" },
+      });
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: "base-sha-123" } },
+      });
+      mockOctokit.rest.git.createRef.mockResolvedValue({});
+      mockOctokit.rest.repos.getContent.mockRejectedValue({ status: 404 });
+      mockOctokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({});
+      mockOctokit.rest.pulls.create.mockResolvedValue({
+        data: { number: 42, html_url: "https://github.com/owner/repo/pull/42" },
+      });
+    });
+
+    it("should create a PR with correct structure", async () => {
+      const result = await createPR({
+        owner: "owner",
+        repo: "repo",
+        installationId: 123,
+        spec: "openapi: 3.0.3",
+        parseResult: sampleParseResult,
+        commitSha: "abc1234567890",
+        version: "1.0.0",
+      });
+
+      expect(result.prNumber).toBe(42);
+      expect(result.prUrl).toBe("https://github.com/owner/repo/pull/42");
+    });
+
+    it("should create branch from default branch HEAD", async () => {
+      await createPR({
+        owner: "owner",
+        repo: "repo",
+        installationId: 123,
+        spec: "spec",
+        parseResult: emptyParseResult,
+        commitSha: "abc1234",
+        version: "1.0.0",
+      });
+
+      expect(mockOctokit.rest.git.createRef).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sha: "base-sha-123",
+          ref: expect.stringMatching(/^refs\/heads\/autodocapi\/docs-/),
+        })
+      );
+    });
+
+    it("should use custom docsOutput path", async () => {
+      await createPR({
+        owner: "owner",
+        repo: "repo",
+        installationId: 123,
+        spec: "spec",
+        parseResult: emptyParseResult,
+        commitSha: "abc1234",
+        version: "1.0.0",
+        docsOutput: "api/spec.yaml",
+      });
+
+      expect(mockOctokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: "api/spec.yaml",
+        })
+      );
+    });
+
+    it("should reject path traversal in docsOutput", async () => {
+      await expect(
+        createPR({
+          owner: "owner",
+          repo: "repo",
+          installationId: 123,
+          spec: "spec",
+          parseResult: emptyParseResult,
+          commitSha: "abc1234",
+          version: "1.0.0",
+          docsOutput: "../../.github/workflows/evil.yml",
+        })
+      ).rejects.toThrow("Unsafe file path rejected");
+    });
+
+    it("should include existing file SHA when updating", async () => {
+      mockOctokit.rest.repos.getContent.mockResolvedValueOnce({
+        data: { type: "file", sha: "existing-sha-456" },
+      });
+
+      await createPR({
+        owner: "owner",
+        repo: "repo",
+        installationId: 123,
+        spec: "spec",
+        parseResult: emptyParseResult,
+        commitSha: "abc1234",
+        version: "1.0.0",
+      });
+
+      expect(mockOctokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sha: "existing-sha-456",
+        })
+      );
+    });
+  });
+});

--- a/test/github/repoManager.test.ts
+++ b/test/github/repoManager.test.ts
@@ -1,0 +1,137 @@
+import fsSync from "fs";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+jest.mock("../../src/config", () => ({
+  config: {
+    timeouts: { cloneMs: 30000 },
+  },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    })),
+  },
+}));
+
+import { removeSensitiveFiles, cleanup } from "../../src/github/repoManager";
+
+function createTempDir(files: string[]): string {
+  const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "repo-mgr-test-"));
+  for (const f of files) {
+    const filePath = path.join(dir, f);
+    const fileDir = path.dirname(filePath);
+    fsSync.mkdirSync(fileDir, { recursive: true });
+    fsSync.writeFileSync(filePath, "test content");
+  }
+  return dir;
+}
+
+describe("repoManager", () => {
+  describe("removeSensitiveFiles", () => {
+    let tmpDir: string;
+
+    afterEach(async () => {
+      if (tmpDir) {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should remove .env file", async () => {
+      tmpDir = createTempDir([".env", "index.ts"]);
+      await removeSensitiveFiles(tmpDir);
+
+      expect(fsSync.existsSync(path.join(tmpDir, ".env"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "index.ts"))).toBe(true);
+    });
+
+    it("should remove credentials.json", async () => {
+      tmpDir = createTempDir(["credentials.json", "app.ts"]);
+      await removeSensitiveFiles(tmpDir);
+
+      expect(fsSync.existsSync(path.join(tmpDir, "credentials.json"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "app.ts"))).toBe(true);
+    });
+
+    it("should remove service-account.json", async () => {
+      tmpDir = createTempDir(["service-account.json"]);
+      await removeSensitiveFiles(tmpDir);
+
+      expect(fsSync.existsSync(path.join(tmpDir, "service-account.json"))).toBe(false);
+    });
+
+    it("should remove .env.* prefixed files", async () => {
+      tmpDir = createTempDir([".env.local", ".env.production", "safe.txt"]);
+      await removeSensitiveFiles(tmpDir);
+
+      expect(fsSync.existsSync(path.join(tmpDir, ".env.local"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, ".env.production"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "safe.txt"))).toBe(true);
+    });
+
+    it("should remove files with sensitive extensions", async () => {
+      tmpDir = createTempDir(["server.pem", "private.key", "cert.pfx", "auth.p12", "app.ts"]);
+      await removeSensitiveFiles(tmpDir);
+
+      expect(fsSync.existsSync(path.join(tmpDir, "server.pem"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "private.key"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "cert.pfx"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "auth.p12"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "app.ts"))).toBe(true);
+    });
+
+    it("should remove sensitive files in subdirectories", async () => {
+      tmpDir = createTempDir(["config/.env", "keys/server.pem", "src/app.ts"]);
+      await removeSensitiveFiles(tmpDir);
+
+      expect(fsSync.existsSync(path.join(tmpDir, "config", ".env"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "keys", "server.pem"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "src", "app.ts"))).toBe(true);
+    });
+
+    it("should remove appsettings Development and Local variants", async () => {
+      tmpDir = createTempDir([
+        "appsettings.Development.json",
+        "appsettings.Local.json",
+        "appsettings.json",
+      ]);
+      await removeSensitiveFiles(tmpDir);
+
+      expect(fsSync.existsSync(path.join(tmpDir, "appsettings.Development.json"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "appsettings.Local.json"))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, "appsettings.json"))).toBe(true);
+    });
+
+    it("should not remove safe files", async () => {
+      tmpDir = createTempDir(["package.json", "README.md", "src/index.ts"]);
+      await removeSensitiveFiles(tmpDir);
+
+      expect(fsSync.existsSync(path.join(tmpDir, "package.json"))).toBe(true);
+      expect(fsSync.existsSync(path.join(tmpDir, "README.md"))).toBe(true);
+      expect(fsSync.existsSync(path.join(tmpDir, "src", "index.ts"))).toBe(true);
+    });
+
+    it("should handle empty directory", async () => {
+      tmpDir = createTempDir([]);
+      await expect(removeSensitiveFiles(tmpDir)).resolves.not.toThrow();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should remove the directory and all contents", async () => {
+      const tmpDir = createTempDir(["file1.ts", "sub/file2.ts"]);
+      expect(fsSync.existsSync(tmpDir)).toBe(true);
+
+      await cleanup(tmpDir);
+      expect(fsSync.existsSync(tmpDir)).toBe(false);
+    });
+  });
+});

--- a/test/pipeline/processAnalysis.test.ts
+++ b/test/pipeline/processAnalysis.test.ts
@@ -1,0 +1,194 @@
+jest.mock("../../src/config", () => ({
+  config: {
+    github: { appId: "test", privateKeyPath: "/test.pem", webhookSecret: "secret" },
+    timeouts: { cloneMs: 30000, parseMs: 60000, prMs: 15000 },
+    limits: { maxConcurrentAnalyses: 3, rateLimitPerHour: 10 },
+  },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  createChildLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    })),
+  },
+}));
+
+const mockGetValidToken = jest.fn().mockResolvedValue("mock-token");
+jest.mock("../../src/github/appAuth", () => ({
+  getValidToken: mockGetValidToken,
+}));
+
+const mockCheckRepoPermissions = jest.fn().mockResolvedValue({ canPush: true, archived: false });
+const mockCreatePR = jest.fn().mockResolvedValue({ prNumber: 1, prUrl: "https://example.com/pr/1" });
+jest.mock("../../src/github/prService", () => ({
+  checkRepoPermissions: mockCheckRepoPermissions,
+  createPR: mockCreatePR,
+}));
+
+const mockCloneRepo = jest.fn().mockResolvedValue("/tmp/test-repo");
+const mockRemoveSensitiveFiles = jest.fn().mockResolvedValue(undefined);
+const mockCleanup = jest.fn().mockResolvedValue(undefined);
+jest.mock("../../src/github/repoManager", () => ({
+  cloneRepo: mockCloneRepo,
+  removeSensitiveFiles: mockRemoveSensitiveFiles,
+  cleanup: mockCleanup,
+}));
+
+jest.mock("../../src/config/autodocConfig", () => ({
+  loadAutodocConfig: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock("../../src/detector/frameworkDetector", () => ({
+  detectFramework: jest.fn().mockResolvedValue("EXPRESS"),
+  Framework: { EXPRESS: "EXPRESS" },
+}));
+
+jest.mock("../../src/parser/expressParser", () => ({
+  parseExpressRoutes: jest.fn().mockResolvedValue({
+    routes: [{ path: "/api/test", method: "GET", controller: null, routePrefix: null, params: [], requestBody: null, responses: [], auth: null, middleware: [], description: null, source: "test.ts" }],
+    errors: [],
+  }),
+}));
+
+jest.mock("../../src/generator/openApiGenerator", () => ({
+  generateOpenApiSpec: jest.fn().mockReturnValue("openapi: 3.0.3\ninfo:\n  title: test"),
+}));
+
+// DB mocks
+const mockUpdateWhere = jest.fn().mockResolvedValue({ rowCount: 1 });
+const mockUpdateSet = jest.fn(() => ({ where: mockUpdateWhere }));
+const mockDbUpdate = jest.fn(() => ({ set: mockUpdateSet }));
+
+const mockInsertReturning = jest.fn().mockResolvedValue([{ id: 1 }]);
+const mockInsertValues = jest.fn(() => ({ returning: mockInsertReturning }));
+const mockDbInsert = jest.fn(() => ({ values: mockInsertValues }));
+
+const mockSelectLimit = jest.fn().mockResolvedValue([{ id: 1 }]);
+const mockSelectWhere = jest.fn(() => ({ limit: mockSelectLimit }));
+const mockSelectFrom = jest.fn(() => ({ where: mockSelectWhere }));
+const mockDbSelect = jest.fn(() => ({ from: mockSelectFrom }));
+
+jest.mock("../../src/db/connection", () => ({
+  db: {
+    update: mockDbUpdate,
+    insert: mockDbInsert,
+    select: mockDbSelect,
+  },
+}));
+
+jest.mock("../../src/db/schema", () => ({
+  analyses: {},
+  installations: { githubInstallationId: "github_installation_id" },
+  repos: { repoFullName: "repo_full_name" },
+  webhookEvents: { id: "id" },
+}));
+
+jest.mock("@octokit/rest", () => ({
+  Octokit: jest.fn(() => ({
+    rest: {
+      repos: { listTags: jest.fn().mockResolvedValue({ data: [] }) },
+    },
+  })),
+}));
+
+import { processAnalysis } from "../../src/pipeline/processAnalysis";
+import type { QueueItem } from "../../src/queue/analysisQueue";
+
+function makeQueueItem(overrides: Partial<QueueItem> = {}): QueueItem {
+  return {
+    id: "test-item",
+    repoFullName: "owner/repo",
+    payload: {
+      repository: { owner: { login: "owner" }, name: "repo" },
+      installation: { id: 123 },
+      workflow_run: { head_sha: "abc1234567890" },
+    },
+    addedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("processAnalysis", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetValidToken.mockResolvedValue("mock-token");
+    mockCheckRepoPermissions.mockResolvedValue({ canPush: true, archived: false });
+    mockCloneRepo.mockResolvedValue("/tmp/test-repo");
+    mockSelectLimit.mockResolvedValue([{ id: 1 }]);
+  });
+
+  it("should complete the full pipeline successfully", async () => {
+    await processAnalysis(makeQueueItem());
+
+    expect(mockGetValidToken).toHaveBeenCalledWith(123);
+    expect(mockCloneRepo).toHaveBeenCalled();
+    expect(mockRemoveSensitiveFiles).toHaveBeenCalled();
+    expect(mockCreatePR).toHaveBeenCalled();
+    expect(mockCleanup).toHaveBeenCalledWith("/tmp/test-repo");
+  });
+
+  it("should return early on malformed payload", async () => {
+    const item = makeQueueItem({ payload: {} });
+    await processAnalysis(item);
+
+    expect(mockGetValidToken).not.toHaveBeenCalled();
+    expect(mockCloneRepo).not.toHaveBeenCalled();
+  });
+
+  it("should skip analysis when repo has no push permission", async () => {
+    mockCheckRepoPermissions.mockResolvedValue({ canPush: false, archived: false });
+
+    await processAnalysis(makeQueueItem());
+
+    expect(mockCloneRepo).not.toHaveBeenCalled();
+    expect(mockCreatePR).not.toHaveBeenCalled();
+  });
+
+  it("should skip analysis when repo is archived", async () => {
+    mockCheckRepoPermissions.mockResolvedValue({ canPush: true, archived: true });
+
+    await processAnalysis(makeQueueItem());
+
+    expect(mockCloneRepo).not.toHaveBeenCalled();
+  });
+
+  it("should cleanup even on error", async () => {
+    mockCreatePR.mockRejectedValueOnce(new Error("PR creation failed"));
+
+    await expect(processAnalysis(makeQueueItem())).rejects.toThrow("PR creation failed");
+    expect(mockCleanup).toHaveBeenCalledWith("/tmp/test-repo");
+  });
+
+  it("should propagate token fetch errors", async () => {
+    mockGetValidToken.mockRejectedValueOnce(new Error("Auth failed"));
+
+    await expect(processAnalysis(makeQueueItem())).rejects.toThrow("Auth failed");
+  });
+
+  it("should update webhook status to processing", async () => {
+    await processAnalysis(makeQueueItem({ webhookEventId: 42 }));
+
+    expect(mockDbUpdate).toHaveBeenCalled();
+  });
+
+  it("should pass version to createPR", async () => {
+    await processAnalysis(makeQueueItem());
+
+    expect(mockCreatePR).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: expect.any(String),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Added 45 new tests covering every previously untested module in the pipeline:

| Test File | Tests | Covers |
|---|---|---|
| `test/github/repoManager.test.ts` | 10 | Sensitive file detection (exact, prefix, extension), subdirs, cleanup |
| `test/github/appAuth.test.ts` | 5 | JWT creation (iat/exp), token caching, refresh, upsert fallback |
| `test/github/prService.test.ts` | 8 | Permissions, PR creation flow, path sanitization, file update |
| `test/api/webhookHandler.test.ts` | 14 | Signature verification, event dispatch, installation CRUD, rate limiting |
| `test/pipeline/processAnalysis.test.ts` | 8 | Full pipeline, payload validation, permission check, cleanup on error |

**Before:** 162 tests (parsers + generator + detector + basic infra)
**After:** 207 tests (full pipeline coverage)

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx jest` — 207/207 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)